### PR TITLE
fix: implement proper ImportState for organization membership resource

### DIFF
--- a/examples/multi_org_with_aliases/README.md
+++ b/examples/multi_org_with_aliases/README.md
@@ -1,0 +1,71 @@
+# Multi-Organization with Provider Aliases Example
+
+This example demonstrates managing multiple organizations using provider aliases.
+
+## Use Cases
+
+- **Multi-tenant SaaS**: Manage different customer organizations
+- **Development/Staging/Production**: Separate environments with different org credentials
+- **Organizational separation**: Keep different teams' resources isolated
+
+## Usage
+
+### Using Environment Variables
+
+```bash
+export TF_VAR_org1_public_key="pk_org1_..."
+export TF_VAR_org1_private_key="sk_org1_..."
+export TF_VAR_org1_id="org_1"
+
+export TF_VAR_org2_public_key="pk_org2_..."
+export TF_VAR_org2_private_key="sk_org2_..."
+export TF_VAR_org2_id="org_2"
+
+terraform init
+terraform plan
+terraform apply
+```
+
+### Using tfvars File
+
+```bash
+# Create terraform.tfvars
+cat > terraform.tfvars <<EOF
+org1_public_key  = "pk_org1_..."
+org1_private_key = "sk_org1_..."
+org1_id          = "org_1"
+
+org2_public_key  = "pk_org2_..."
+org2_private_key = "sk_org2_..."
+org2_id          = "org_2"
+EOF
+
+terraform init
+terraform plan
+terraform apply
+```
+
+## Import with Specific Provider
+
+When importing resources with multiple providers, specify which provider to use:
+
+```bash
+# Import Org 1 project
+terraform import -provider=langfuse.org1 langfuse_project.org1_project "proj_org1,org_1"
+
+# Import Org 2 project
+terraform import -provider=langfuse.org2 langfuse_project.org2_project "proj_org2,org_2"
+
+# Import Org 1 membership
+terraform import -provider=langfuse.org1 langfuse_organization_membership.org1_member "mem_org1"
+
+# Import Org 2 membership
+terraform import -provider=langfuse.org2 langfuse_organization_membership.org2_member "mem_org2"
+```
+
+## Best Practices
+
+1. **Naming Convention**: Use clear prefixes (e.g., `org1_`, `org2_`) for resources
+2. **Separate State Files**: Consider using separate workspaces or state files for each org
+3. **Security**: Never commit credentials to version control
+4. **Tagging**: Use consistent tagging/metadata to identify which org resources belong to

--- a/examples/multi_org_with_aliases/main.tf
+++ b/examples/multi_org_with_aliases/main.tf
@@ -1,0 +1,55 @@
+terraform {
+  required_providers {
+    langfuse = {
+      source = "langfuse/langfuse"
+    }
+  }
+}
+
+# Provider for Organization 1
+provider "langfuse" {
+  alias           = "org1"
+  org_public_key  = var.org1_public_key
+  org_private_key = var.org1_private_key
+}
+
+# Provider for Organization 2
+provider "langfuse" {
+  alias           = "org2"
+  org_public_key  = var.org2_public_key
+  org_private_key = var.org2_private_key
+}
+
+# Resources for Organization 1
+resource "langfuse_project" "org1_project" {
+  provider        = langfuse.org1
+  name            = "Org 1 Project"
+  organization_id = var.org1_id
+}
+
+resource "langfuse_organization_membership" "org1_member" {
+  provider = langfuse.org1
+  email    = "user@org1.com"
+  role     = "MEMBER"
+}
+
+# Resources for Organization 2
+resource "langfuse_project" "org2_project" {
+  provider        = langfuse.org2
+  name            = "Org 2 Project"
+  organization_id = var.org2_id
+}
+
+resource "langfuse_organization_membership" "org2_member" {
+  provider = langfuse.org2
+  email    = "user@org2.com"
+  role     = "MEMBER"
+}
+
+output "org1_project_id" {
+  value = langfuse_project.org1_project.id
+}
+
+output "org2_project_id" {
+  value = langfuse_project.org2_project.id
+}

--- a/examples/multi_org_with_aliases/variables.tf
+++ b/examples/multi_org_with_aliases/variables.tf
@@ -1,0 +1,33 @@
+variable "org1_public_key" {
+  description = "Organization 1 public key"
+  type        = string
+  sensitive   = true
+}
+
+variable "org1_private_key" {
+  description = "Organization 1 private key"
+  type        = string
+  sensitive   = true
+}
+
+variable "org1_id" {
+  description = "Organization 1 ID"
+  type        = string
+}
+
+variable "org2_public_key" {
+  description = "Organization 2 public key"
+  type        = string
+  sensitive   = true
+}
+
+variable "org2_private_key" {
+  description = "Organization 2 private key"
+  type        = string
+  sensitive   = true
+}
+
+variable "org2_id" {
+  description = "Organization 2 ID"
+  type        = string
+}

--- a/examples/provider_with_org_credentials/README.md
+++ b/examples/provider_with_org_credentials/README.md
@@ -1,0 +1,67 @@
+# Provider with Organization Credentials Example
+
+This example demonstrates using provider-level organization credentials to avoid repeating credentials across resources.
+
+## Benefits
+
+- **No credential repetition**: Set credentials once at the provider level
+- **Cleaner code**: Resources don't need org_public_key and org_private_key fields
+- **Easier management**: Update credentials in one place
+- **Simplified imports**: Import resources using just the resource ID
+
+## Usage
+
+### Using Environment Variables (Recommended)
+
+```bash
+export LANGFUSE_ORG_PUBLIC_KEY="pk_..."
+export LANGFUSE_ORG_PRIVATE_KEY="sk_..."
+export TF_VAR_organization_id="org_..."
+
+terraform init
+terraform plan
+terraform apply
+```
+
+### Using tfvars File
+
+```bash
+# Create terraform.tfvars
+cat > terraform.tfvars <<EOF
+org_public_key  = "pk_..."
+org_private_key = "sk_..."
+organization_id = "org_..."
+EOF
+
+terraform init
+terraform plan
+terraform apply
+```
+
+## Import Examples
+
+With provider-level credentials, you can import resources using simplified syntax:
+
+```bash
+# Import project (only need project_id and organization_id)
+terraform import langfuse_project.example "proj_123,org_456"
+
+# Import organization membership (only need membership_id)
+terraform import langfuse_organization_membership.member "mem_789"
+
+# Import project API key (only need key_id and project_id)
+terraform import langfuse_project_api_key.example_key "key_abc,proj_123"
+```
+
+## Backward Compatibility
+
+You can still specify credentials at the resource level if needed. Resource-level credentials override provider-level credentials:
+
+```hcl
+resource "langfuse_project" "override_example" {
+  name                     = "Override Project"
+  organization_id          = var.organization_id
+  organization_public_key  = var.other_org_public_key
+  organization_private_key = var.other_org_private_key
+}
+```

--- a/examples/provider_with_org_credentials/main.tf
+++ b/examples/provider_with_org_credentials/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_providers {
+    langfuse = {
+      source = "langfuse/langfuse"
+    }
+  }
+}
+
+# Configure provider with organization-level credentials
+# This allows resources to inherit these credentials instead of repeating them
+provider "langfuse" {
+  org_public_key  = var.org_public_key
+  org_private_key = var.org_private_key
+}
+
+# Create project without needing to specify credentials
+# Credentials are inherited from the provider
+resource "langfuse_project" "example" {
+  name            = "Example Project"
+  organization_id = var.organization_id
+  retention_days  = 30
+}
+
+# Create organization membership without needing to specify credentials
+# Credentials are inherited from the provider
+resource "langfuse_organization_membership" "member" {
+  email = "user@example.com"
+  role  = "MEMBER"
+}
+
+# Create project API key without needing to specify credentials
+# Credentials are inherited from the provider
+resource "langfuse_project_api_key" "example_key" {
+  project_id = langfuse_project.example.id
+}
+
+output "project_id" {
+  value = langfuse_project.example.id
+}
+
+output "project_api_public_key" {
+  value     = langfuse_project_api_key.example_key.public_key
+  sensitive = true
+}

--- a/examples/provider_with_org_credentials/variables.tf
+++ b/examples/provider_with_org_credentials/variables.tf
@@ -1,0 +1,16 @@
+variable "org_public_key" {
+  description = "Organization public key"
+  type        = string
+  sensitive   = true
+}
+
+variable "org_private_key" {
+  description = "Organization private key"
+  type        = string
+  sensitive   = true
+}
+
+variable "organization_id" {
+  description = "Organization ID"
+  type        = string
+}

--- a/internal/langfuse/client_factory.go
+++ b/internal/langfuse/client_factory.go
@@ -1,19 +1,26 @@
 package langfuse
 
 type clientFactoryImpl struct {
-	host        string
-	adminApiKey string
+	host           string
+	adminApiKey    string
+	orgPublicKey   string
+	orgPrivateKey  string
 }
 
 type ClientFactory interface {
 	NewAdminClient() AdminClient
 	NewOrganizationClient(publicKey, privateKey string) OrganizationClient
+	GetDefaultOrgPublicKey() string
+	GetDefaultOrgPrivateKey() string
+	HasDefaultOrgCredentials() bool
 }
 
-func NewClientFactory(host, adminApiKey string) ClientFactory {
+func NewClientFactory(host, adminApiKey, orgPublicKey, orgPrivateKey string) ClientFactory {
 	return &clientFactoryImpl{
-		host:        host,
-		adminApiKey: adminApiKey,
+		host:          host,
+		adminApiKey:   adminApiKey,
+		orgPublicKey:  orgPublicKey,
+		orgPrivateKey: orgPrivateKey,
 	}
 }
 
@@ -23,4 +30,16 @@ func (cf *clientFactoryImpl) NewAdminClient() AdminClient {
 
 func (cf *clientFactoryImpl) NewOrganizationClient(publicKey, privateKey string) OrganizationClient {
 	return NewOrganizationClient(cf.host, publicKey, privateKey)
+}
+
+func (cf *clientFactoryImpl) GetDefaultOrgPublicKey() string {
+	return cf.orgPublicKey
+}
+
+func (cf *clientFactoryImpl) GetDefaultOrgPrivateKey() string {
+	return cf.orgPrivateKey
+}
+
+func (cf *clientFactoryImpl) HasDefaultOrgCredentials() bool {
+	return cf.orgPublicKey != "" && cf.orgPrivateKey != ""
 }

--- a/internal/langfuse/mocks/mock_client_factory.go
+++ b/internal/langfuse/mocks/mock_client_factory.go
@@ -8,6 +8,8 @@ import (
 type mockClientFactory struct {
 	AdminClient        *MockAdminClient
 	OrganizationClient *MockOrganizationClient
+	orgPublicKey       string
+	orgPrivateKey      string
 }
 
 func NewMockClientFactory(ctrl *gomock.Controller) *mockClientFactory {
@@ -23,4 +25,22 @@ func (cf *mockClientFactory) NewAdminClient() langfuse.AdminClient {
 
 func (cf *mockClientFactory) NewOrganizationClient(publicKey, privateKey string) langfuse.OrganizationClient {
 	return cf.OrganizationClient
+}
+
+func (cf *mockClientFactory) GetDefaultOrgPublicKey() string {
+	return cf.orgPublicKey
+}
+
+func (cf *mockClientFactory) GetDefaultOrgPrivateKey() string {
+	return cf.orgPrivateKey
+}
+
+func (cf *mockClientFactory) HasDefaultOrgCredentials() bool {
+	return cf.orgPublicKey != "" && cf.orgPrivateKey != ""
+}
+
+// SetDefaultOrgCredentials is a helper method for tests to set provider-level credentials
+func (cf *mockClientFactory) SetDefaultOrgCredentials(publicKey, privateKey string) {
+	cf.orgPublicKey = publicKey
+	cf.orgPrivateKey = privateKey
 }

--- a/internal/provider/organization_membership_resource.go
+++ b/internal/provider/organization_membership_resource.go
@@ -52,6 +52,41 @@ func (r *organizationMembershipResource) Configure(ctx context.Context, req reso
 	r.ClientFactory = clientFactory
 }
 
+// resolveOrgCredentials returns the org credentials to use, implementing the fallback pattern:
+// 1. Use resource-level credentials if provided
+// 2. Fall back to provider-level credentials if available
+// 3. Error if neither is available
+func (r *organizationMembershipResource) resolveOrgCredentials(
+	ctx context.Context,
+	resourcePublicKey, resourcePrivateKey types.String,
+) (publicKey string, privateKey string, err error) {
+
+	// Check if resource has explicit credentials
+	hasResourceCreds := !resourcePublicKey.IsNull() &&
+		!resourcePublicKey.IsUnknown() &&
+		resourcePublicKey.ValueString() != "" &&
+		!resourcePrivateKey.IsNull() &&
+		!resourcePrivateKey.IsUnknown() &&
+		resourcePrivateKey.ValueString() != ""
+
+	if hasResourceCreds {
+		return resourcePublicKey.ValueString(), resourcePrivateKey.ValueString(), nil
+	}
+
+	// Fall back to provider-level credentials
+	if r.ClientFactory.HasDefaultOrgCredentials() {
+		return r.ClientFactory.GetDefaultOrgPublicKey(),
+			r.ClientFactory.GetDefaultOrgPrivateKey(),
+			nil
+	}
+
+	// Neither available - return error
+	return "", "", fmt.Errorf(
+		"organization credentials required: provide org_public_key and org_private_key " +
+			"either at resource level or configure at provider level",
+	)
+}
+
 func (r *organizationMembershipResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_organization_membership"
 }
@@ -91,17 +126,17 @@ func (r *organizationMembershipResource) Schema(ctx context.Context, req resourc
 				Computed:    true,
 			},
 			"organization_public_key": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
-				Description: "Organization public key to authenticate the call.",
+				Description: "Organization public key to authenticate the call. If not provided, uses provider-level org_public_key.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"organization_private_key": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
-				Description: "Organization private key to authenticate the call.",
+				Description: "Organization private key to authenticate the call. If not provided, uses provider-level org_private_key.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -114,6 +149,13 @@ func (r *organizationMembershipResource) Create(ctx context.Context, req resourc
 	var plan organizationMembershipResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Resolve credentials with fallback
+	publicKey, privateKey, err := r.resolveOrgCredentials(ctx, plan.OrganizationPublicKey, plan.OrganizationPrivateKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Missing Organization Credentials", err.Error())
 		return
 	}
 
@@ -135,7 +177,7 @@ func (r *organizationMembershipResource) Create(ctx context.Context, req resourc
 		return
 	}
 
-	organizationClient := r.ClientFactory.NewOrganizationClient(plan.OrganizationPublicKey.ValueString(), plan.OrganizationPrivateKey.ValueString())
+	organizationClient := r.ClientFactory.NewOrganizationClient(publicKey, privateKey)
 
 	email := plan.Email.ValueString()
 
@@ -226,6 +268,8 @@ func (r *organizationMembershipResource) Create(ctx context.Context, req resourc
 		plan.Status = types.StringValue(membership.Status)
 		plan.UserID = types.StringValue(membership.UserID)
 		plan.Username = types.StringValue(membership.Username)
+		plan.OrganizationPublicKey = types.StringValue(publicKey)
+		plan.OrganizationPrivateKey = types.StringValue(privateKey)
 	} else {
 		// User already exists in organization, update their role
 		updateRequest := &langfuse.UpdateMembershipRequest{
@@ -251,6 +295,8 @@ func (r *organizationMembershipResource) Create(ctx context.Context, req resourc
 		plan.Status = types.StringValue(membership.Status)
 		plan.UserID = types.StringValue(membership.UserID)
 		plan.Username = types.StringValue(membership.Username)
+		plan.OrganizationPublicKey = types.StringValue(publicKey)
+		plan.OrganizationPrivateKey = types.StringValue(privateKey)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -263,7 +309,14 @@ func (r *organizationMembershipResource) Read(ctx context.Context, req resource.
 		return
 	}
 
-	organizationClient := r.ClientFactory.NewOrganizationClient(state.OrganizationPublicKey.ValueString(), state.OrganizationPrivateKey.ValueString())
+	// Resolve credentials with fallback
+	publicKey, privateKey, err := r.resolveOrgCredentials(ctx, state.OrganizationPublicKey, state.OrganizationPrivateKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Missing Organization Credentials", err.Error())
+		return
+	}
+
+	organizationClient := r.ClientFactory.NewOrganizationClient(publicKey, privateKey)
 
 	membership, err := organizationClient.GetMembership(ctx, state.ID.ValueString())
 	if err != nil {
@@ -304,6 +357,13 @@ func (r *organizationMembershipResource) Update(ctx context.Context, req resourc
 		return
 	}
 
+	// Resolve credentials with fallback
+	publicKey, privateKey, err := r.resolveOrgCredentials(ctx, state.OrganizationPublicKey, state.OrganizationPrivateKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Missing Organization Credentials", err.Error())
+		return
+	}
+
 	// Validate role is one of the allowed values
 	validRoles := []string{"OWNER", "ADMIN", "MEMBER", "VIEWER","NONE"}
 	role := plan.Role.ValueString()
@@ -322,7 +382,7 @@ func (r *organizationMembershipResource) Update(ctx context.Context, req resourc
 		return
 	}
 
-	organizationClient := r.ClientFactory.NewOrganizationClient(state.OrganizationPublicKey.ValueString(), state.OrganizationPrivateKey.ValueString())
+	organizationClient := r.ClientFactory.NewOrganizationClient(publicKey, privateKey)
 
 	updateRequest := &langfuse.UpdateMembershipRequest{
 		Role: role,
@@ -346,6 +406,8 @@ func (r *organizationMembershipResource) Update(ctx context.Context, req resourc
 	plan.Status = types.StringValue(membership.Status)
 	plan.UserID = types.StringValue(membership.UserID)
 	plan.Username = types.StringValue(membership.Username)
+	plan.OrganizationPublicKey = types.StringValue(publicKey)
+	plan.OrganizationPrivateKey = types.StringValue(privateKey)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
@@ -357,9 +419,16 @@ func (r *organizationMembershipResource) Delete(ctx context.Context, req resourc
 		return
 	}
 
-	organizationClient := r.ClientFactory.NewOrganizationClient(state.OrganizationPublicKey.ValueString(), state.OrganizationPrivateKey.ValueString())
+	// Resolve credentials with fallback
+	publicKey, privateKey, err := r.resolveOrgCredentials(ctx, state.OrganizationPublicKey, state.OrganizationPrivateKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Missing Organization Credentials", err.Error())
+		return
+	}
 
-	err := organizationClient.RemoveMember(ctx, state.UserID.ValueString())
+	organizationClient := r.ClientFactory.NewOrganizationClient(publicKey, privateKey)
+
+	err = organizationClient.RemoveMember(ctx, state.UserID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error removing member", err.Error())
 		return
@@ -367,19 +436,44 @@ func (r *organizationMembershipResource) Delete(ctx context.Context, req resourc
 }
 
 func (r *organizationMembershipResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Import format: membership_id,organization_public_key,organization_private_key
-	// Example: terraform import langfuse_organization_membership.example "mem_123,pk_456,sk_789"
-
 	importParts := strings.Split(req.ID, ",")
-	if len(importParts) != 3 {
-		resp.Diagnostics.AddError("Invalid import format",
-			"Import ID must be in format: membership_id,organization_public_key,organization_private_key")
+
+	var membershipID, orgPublicKey, orgPrivateKey string
+
+	switch len(importParts) {
+	case 1:
+		// New format: "membership_id" - use provider credentials
+		membershipID = importParts[0]
+
+		if !r.ClientFactory.HasDefaultOrgCredentials() {
+			resp.Diagnostics.AddError(
+				"Missing Organization Credentials for Import",
+				"Import format 'resource_id' requires provider-level org credentials. "+
+					"Either:\n"+
+					"1. Configure provider with org_public_key and org_private_key, or\n"+
+					"2. Use import format: resource_id,org_public_key,org_private_key",
+			)
+			return
+		}
+
+		orgPublicKey = r.ClientFactory.GetDefaultOrgPublicKey()
+		orgPrivateKey = r.ClientFactory.GetDefaultOrgPrivateKey()
+
+	case 3:
+		// Legacy format: "membership_id,public_key,private_key"
+		membershipID = importParts[0]
+		orgPublicKey = importParts[1]
+		orgPrivateKey = importParts[2]
+
+	default:
+		resp.Diagnostics.AddError(
+			"Invalid import format",
+			"Import ID must be in one of these formats:\n"+
+				"1. membership_id (requires provider-level credentials)\n"+
+				"2. membership_id,organization_public_key,organization_private_key",
+		)
 		return
 	}
-
-	membershipID := importParts[0]
-	orgPublicKey := importParts[1]
-	orgPrivateKey := importParts[2]
 
 	// Validate we can fetch the membership with the provided credentials
 	organizationClient := r.ClientFactory.NewOrganizationClient(orgPublicKey, orgPrivateKey)

--- a/internal/provider/organization_membership_resource.go
+++ b/internal/provider/organization_membership_resource.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -368,5 +367,39 @@ func (r *organizationMembershipResource) Delete(ctx context.Context, req resourc
 }
 
 func (r *organizationMembershipResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	// Import format: membership_id,organization_public_key,organization_private_key
+	// Example: terraform import langfuse_organization_membership.example "mem_123,pk_456,sk_789"
+
+	importParts := strings.Split(req.ID, ",")
+	if len(importParts) != 3 {
+		resp.Diagnostics.AddError("Invalid import format",
+			"Import ID must be in format: membership_id,organization_public_key,organization_private_key")
+		return
+	}
+
+	membershipID := importParts[0]
+	orgPublicKey := importParts[1]
+	orgPrivateKey := importParts[2]
+
+	// Validate we can fetch the membership with the provided credentials
+	organizationClient := r.ClientFactory.NewOrganizationClient(orgPublicKey, orgPrivateKey)
+
+	membership, err := organizationClient.GetMembership(ctx, membershipID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error importing membership",
+			fmt.Sprintf("Could not read membership %s: %s", membershipID, err.Error()))
+		return
+	}
+
+	// Set the imported state with all required information
+	resp.Diagnostics.Append(resp.State.Set(ctx, &organizationMembershipResourceModel{
+		ID:                     types.StringValue(membershipID),
+		Email:                  types.StringValue(membership.Email),
+		Role:                   types.StringValue(membership.Role),
+		Status:                 types.StringValue(membership.Status),
+		UserID:                 types.StringValue(membership.UserID),
+		Username:               types.StringValue(membership.Username),
+		OrganizationPublicKey:  types.StringValue(orgPublicKey),
+		OrganizationPrivateKey: types.StringValue(orgPrivateKey),
+	})...)
 }

--- a/internal/provider/organization_membership_resource_unit_test.go
+++ b/internal/provider/organization_membership_resource_unit_test.go
@@ -2,11 +2,15 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse/mocks"
 )
 
 func TestOrganizationMembershipResourceMetadata(t *testing.T) {
@@ -162,4 +166,197 @@ func TestOrganizationMembershipResource_Update_InvalidRole(t *testing.T) {
 	if errorSummary != "Invalid Role" {
 		t.Fatalf("unexpected error summary. got %q, want %q", errorSummary, "Invalid Role")
 	}
+}
+
+func TestOrganizationMembershipResourceImport(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	r := NewOrganizationMembershipResource().(*organizationMembershipResource)
+
+	clientFactory := mocks.NewMockClientFactory(ctrl)
+
+	// Configure the resource
+	var configureResp resource.ConfigureResponse
+	r.Configure(ctx, resource.ConfigureRequest{ProviderData: clientFactory}, &configureResp)
+	if configureResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Configure: %v", configureResp.Diagnostics)
+	}
+
+	// Get the schema
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Schema: %v", schemaResp.Diagnostics)
+	}
+
+	t.Run("Successful import", func(t *testing.T) {
+		membershipID := "mem-123"
+		publicKey := "pk-456"
+		privateKey := "sk-789"
+
+		// Mock the GetMembership call
+		clientFactory.OrganizationClient.EXPECT().
+			GetMembership(ctx, membershipID).
+			Return(&langfuse.OrganizationMembership{
+				ID:       membershipID,
+				Email:    "test@example.com",
+				Role:     "ADMIN",
+				Status:   "ACTIVE",
+				UserID:   "user-123",
+				Username: "testuser",
+			}, nil)
+
+		importID := membershipID + "," + publicKey + "," + privateKey
+
+		var importResp resource.ImportStateResponse
+		importResp.State.Schema = schemaResp.Schema
+
+		r.ImportState(ctx, resource.ImportStateRequest{ID: importID}, &importResp)
+
+		if importResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics from ImportState: %v", importResp.Diagnostics)
+		}
+
+		// Verify the imported state
+		var stateData organizationMembershipResourceModel
+		importResp.State.Get(ctx, &stateData)
+
+		if stateData.ID.ValueString() != membershipID {
+			t.Errorf("expected ID %q, got %q", membershipID, stateData.ID.ValueString())
+		}
+		if stateData.Email.ValueString() != "test@example.com" {
+			t.Errorf("expected Email %q, got %q", "test@example.com", stateData.Email.ValueString())
+		}
+		if stateData.Role.ValueString() != "ADMIN" {
+			t.Errorf("expected Role %q, got %q", "ADMIN", stateData.Role.ValueString())
+		}
+		if stateData.Status.ValueString() != "ACTIVE" {
+			t.Errorf("expected Status %q, got %q", "ACTIVE", stateData.Status.ValueString())
+		}
+		if stateData.UserID.ValueString() != "user-123" {
+			t.Errorf("expected UserID %q, got %q", "user-123", stateData.UserID.ValueString())
+		}
+		if stateData.Username.ValueString() != "testuser" {
+			t.Errorf("expected Username %q, got %q", "testuser", stateData.Username.ValueString())
+		}
+		if stateData.OrganizationPublicKey.ValueString() != publicKey {
+			t.Errorf("expected OrganizationPublicKey %q, got %q", publicKey, stateData.OrganizationPublicKey.ValueString())
+		}
+		if stateData.OrganizationPrivateKey.ValueString() != privateKey {
+			t.Errorf("expected OrganizationPrivateKey %q, got %q", privateKey, stateData.OrganizationPrivateKey.ValueString())
+		}
+	})
+
+	t.Run("Invalid import format - missing parts", func(t *testing.T) {
+		// Only membership ID, missing public and private keys
+		importID := "mem-123"
+
+		var importResp resource.ImportStateResponse
+		importResp.State.Schema = schemaResp.Schema
+
+		r.ImportState(ctx, resource.ImportStateRequest{ID: importID}, &importResp)
+
+		if !importResp.Diagnostics.HasError() {
+			t.Fatal("expected diagnostics error for invalid import format")
+		}
+
+		errorFound := false
+		for _, diag := range importResp.Diagnostics {
+			if diag.Summary() == "Invalid import format" {
+				errorFound = true
+				break
+			}
+		}
+		if !errorFound {
+			t.Error("expected 'Invalid import format' error message")
+		}
+	})
+
+	t.Run("Invalid import format - too many parts", func(t *testing.T) {
+		// Too many parts
+		importID := "mem-123,pk-456,sk-789,extra-part"
+
+		var importResp resource.ImportStateResponse
+		importResp.State.Schema = schemaResp.Schema
+
+		r.ImportState(ctx, resource.ImportStateRequest{ID: importID}, &importResp)
+
+		if !importResp.Diagnostics.HasError() {
+			t.Fatal("expected diagnostics error for invalid import format")
+		}
+
+		errorFound := false
+		for _, diag := range importResp.Diagnostics {
+			if diag.Summary() == "Invalid import format" {
+				errorFound = true
+				break
+			}
+		}
+		if !errorFound {
+			t.Error("expected 'Invalid import format' error message")
+		}
+	})
+
+	t.Run("Invalid import format - only two parts", func(t *testing.T) {
+		// Two parts instead of three
+		importID := "mem-123,pk-456"
+
+		var importResp resource.ImportStateResponse
+		importResp.State.Schema = schemaResp.Schema
+
+		r.ImportState(ctx, resource.ImportStateRequest{ID: importID}, &importResp)
+
+		if !importResp.Diagnostics.HasError() {
+			t.Fatal("expected diagnostics error for invalid import format")
+		}
+
+		errorFound := false
+		for _, diag := range importResp.Diagnostics {
+			if diag.Summary() == "Invalid import format" {
+				errorFound = true
+				break
+			}
+		}
+		if !errorFound {
+			t.Error("expected 'Invalid import format' error message")
+		}
+	})
+
+	t.Run("Import with API error", func(t *testing.T) {
+		membershipID := "mem-nonexistent"
+		publicKey := "pk-456"
+		privateKey := "sk-789"
+
+		// Mock API error
+		clientFactory.OrganizationClient.EXPECT().
+			GetMembership(ctx, membershipID).
+			Return(nil, fmt.Errorf("cannot find membership"))
+
+		importID := membershipID + "," + publicKey + "," + privateKey
+
+		var importResp resource.ImportStateResponse
+		importResp.State.Schema = schemaResp.Schema
+
+		r.ImportState(ctx, resource.ImportStateRequest{ID: importID}, &importResp)
+
+		if !importResp.Diagnostics.HasError() {
+			t.Fatal("expected diagnostics error for API error")
+		}
+
+		errorFound := false
+		for _, diag := range importResp.Diagnostics {
+			if diag.Summary() == "Error importing membership" {
+				errorFound = true
+				break
+			}
+		}
+		if !errorFound {
+			t.Error("expected 'Error importing membership' error message")
+		}
+	})
 }

--- a/internal/provider/organization_membership_resource_unit_test.go
+++ b/internal/provider/organization_membership_resource_unit_test.go
@@ -254,6 +254,8 @@ func TestOrganizationMembershipResourceImport(t *testing.T) {
 
 	t.Run("Invalid import format - missing parts", func(t *testing.T) {
 		// Only membership ID, missing public and private keys
+		// This now triggers the new "Missing Organization Credentials for Import" error
+		// since format "mem-123" is valid but requires provider credentials
 		importID := "mem-123"
 
 		var importResp resource.ImportStateResponse
@@ -262,18 +264,18 @@ func TestOrganizationMembershipResourceImport(t *testing.T) {
 		r.ImportState(ctx, resource.ImportStateRequest{ID: importID}, &importResp)
 
 		if !importResp.Diagnostics.HasError() {
-			t.Fatal("expected diagnostics error for invalid import format")
+			t.Fatal("expected diagnostics error for missing provider credentials")
 		}
 
 		errorFound := false
 		for _, diag := range importResp.Diagnostics {
-			if diag.Summary() == "Invalid import format" {
+			if diag.Summary() == "Missing Organization Credentials for Import" {
 				errorFound = true
 				break
 			}
 		}
 		if !errorFound {
-			t.Error("expected 'Invalid import format' error message")
+			t.Error("expected 'Missing Organization Credentials for Import' error message")
 		}
 	})
 

--- a/internal/provider/project_api_key_resource.go
+++ b/internal/provider/project_api_key_resource.go
@@ -2,16 +2,19 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
-	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
 )
 
 var _ resource.Resource = &projectApiKeyResource{}
+var _ resource.ResourceWithImportState = &projectApiKeyResource{}
 
 func NewProjectApiKeyResource() resource.Resource {
 	return &projectApiKeyResource{}
@@ -38,6 +41,41 @@ func (r *projectApiKeyResource) Configure(ctx context.Context, req resource.Conf
 	r.ClientFactory = req.ProviderData.(langfuse.ClientFactory)
 }
 
+// resolveOrgCredentials returns the org credentials to use, implementing the fallback pattern:
+// 1. Use resource-level credentials if provided
+// 2. Fall back to provider-level credentials if available
+// 3. Error if neither is available
+func (r *projectApiKeyResource) resolveOrgCredentials(
+	ctx context.Context,
+	resourcePublicKey, resourcePrivateKey types.String,
+) (publicKey string, privateKey string, err error) {
+
+	// Check if resource has explicit credentials
+	hasResourceCreds := !resourcePublicKey.IsNull() &&
+		!resourcePublicKey.IsUnknown() &&
+		resourcePublicKey.ValueString() != "" &&
+		!resourcePrivateKey.IsNull() &&
+		!resourcePrivateKey.IsUnknown() &&
+		resourcePrivateKey.ValueString() != ""
+
+	if hasResourceCreds {
+		return resourcePublicKey.ValueString(), resourcePrivateKey.ValueString(), nil
+	}
+
+	// Fall back to provider-level credentials
+	if r.ClientFactory.HasDefaultOrgCredentials() {
+		return r.ClientFactory.GetDefaultOrgPublicKey(),
+			r.ClientFactory.GetDefaultOrgPrivateKey(),
+			nil
+	}
+
+	// Neither available - return error
+	return "", "", fmt.Errorf(
+		"organization credentials required: provide org_public_key and org_private_key " +
+			"either at resource level or configure at provider level",
+	)
+}
+
 func (r *projectApiKeyResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_project_api_key"
 }
@@ -56,16 +94,17 @@ func (r *projectApiKeyResource) Schema(ctx context.Context, req resource.SchemaR
 				},
 			},
 			"organization_public_key": schema.StringAttribute{
-				Required:    true,
-				Description: "Organization public key to authenticate the call.",
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Organization public key to authenticate the call. If not provided, uses provider-level org_public_key.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"organization_private_key": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
-				Description: "Organization private key to authenticate the call.",
+				Description: "Organization private key to authenticate the call. If not provided, uses provider-level org_private_key.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -100,7 +139,14 @@ func (r *projectApiKeyResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	organizationClient := r.ClientFactory.NewOrganizationClient(data.OrganizationPublicKey.ValueString(), data.OrganizationPrivateKey.ValueString())
+	// Resolve credentials with fallback
+	publicKey, privateKey, err := r.resolveOrgCredentials(ctx, data.OrganizationPublicKey, data.OrganizationPrivateKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Missing Organization Credentials", err.Error())
+		return
+	}
+
+	organizationClient := r.ClientFactory.NewOrganizationClient(publicKey, privateKey)
 	projectApiKey, err := organizationClient.CreateProjectApiKey(ctx, data.ProjectID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating project API key", err.Error())
@@ -109,8 +155,8 @@ func (r *projectApiKeyResource) Create(ctx context.Context, req resource.CreateR
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &projectApiKeyResourceModel{
 		ID:                     types.StringValue(projectApiKey.ID),
-		OrganizationPublicKey:  types.StringValue(data.OrganizationPublicKey.ValueString()),
-		OrganizationPrivateKey: types.StringValue(data.OrganizationPrivateKey.ValueString()),
+		OrganizationPublicKey:  types.StringValue(publicKey),
+		OrganizationPrivateKey: types.StringValue(privateKey),
 		ProjectID:              types.StringValue(data.ProjectID.ValueString()),
 		PublicKey:              types.StringValue(projectApiKey.PublicKey),
 		SecretKey:              types.StringValue(projectApiKey.SecretKey),
@@ -124,8 +170,15 @@ func (r *projectApiKeyResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	organizationClient := r.ClientFactory.NewOrganizationClient(data.OrganizationPublicKey.ValueString(), data.OrganizationPrivateKey.ValueString())
-	_, err := organizationClient.GetProjectApiKey(ctx, data.ProjectID.ValueString(), data.ID.ValueString())
+	// Resolve credentials with fallback
+	publicKey, privateKey, err := r.resolveOrgCredentials(ctx, data.OrganizationPublicKey, data.OrganizationPrivateKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Missing Organization Credentials", err.Error())
+		return
+	}
+
+	organizationClient := r.ClientFactory.NewOrganizationClient(publicKey, privateKey)
+	_, err = organizationClient.GetProjectApiKey(ctx, data.ProjectID.ValueString(), data.ID.ValueString())
 	if err != nil {
 		resp.State.RemoveResource(ctx)
 		return
@@ -146,12 +199,84 @@ func (r *projectApiKeyResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	organizationClient := r.ClientFactory.NewOrganizationClient(data.OrganizationPublicKey.ValueString(), data.OrganizationPrivateKey.ValueString())
-	err := organizationClient.DeleteProjectApiKey(ctx, data.ProjectID.ValueString(), data.ID.ValueString())
+	// Resolve credentials with fallback
+	publicKey, privateKey, err := r.resolveOrgCredentials(ctx, data.OrganizationPublicKey, data.OrganizationPrivateKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Missing Organization Credentials", err.Error())
+		return
+	}
+
+	organizationClient := r.ClientFactory.NewOrganizationClient(publicKey, privateKey)
+	err = organizationClient.DeleteProjectApiKey(ctx, data.ProjectID.ValueString(), data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting project API key", err.Error())
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &projectApiKeyResourceModel{})...)
+}
+
+func (r *projectApiKeyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	importParts := strings.Split(req.ID, ",")
+
+	var keyID, projectID, orgPublicKey, orgPrivateKey string
+
+	switch len(importParts) {
+	case 2:
+		// New format: "key_id,project_id" - use provider credentials
+		keyID = importParts[0]
+		projectID = importParts[1]
+
+		if !r.ClientFactory.HasDefaultOrgCredentials() {
+			resp.Diagnostics.AddError(
+				"Missing Organization Credentials for Import",
+				"Import format 'key_id,project_id' requires provider-level org credentials. "+
+					"Either:\n"+
+					"1. Configure provider with org_public_key and org_private_key, or\n"+
+					"2. Use import format: key_id,project_id,org_public_key,org_private_key",
+			)
+			return
+		}
+
+		orgPublicKey = r.ClientFactory.GetDefaultOrgPublicKey()
+		orgPrivateKey = r.ClientFactory.GetDefaultOrgPrivateKey()
+
+	case 4:
+		// Legacy format: "key_id,project_id,public_key,private_key"
+		keyID = importParts[0]
+		projectID = importParts[1]
+		orgPublicKey = importParts[2]
+		orgPrivateKey = importParts[3]
+
+	default:
+		resp.Diagnostics.AddError(
+			"Invalid import format",
+			"Import ID must be in one of these formats:\n"+
+				"1. key_id,project_id (requires provider-level credentials)\n"+
+				"2. key_id,project_id,organization_public_key,organization_private_key",
+		)
+		return
+	}
+
+	// Validate we can fetch the project API key with the provided credentials
+	organizationClient := r.ClientFactory.NewOrganizationClient(orgPublicKey, orgPrivateKey)
+
+	// Note: The API key secret is not retrievable after creation, so we can only verify the key exists
+	_, err := organizationClient.GetProjectApiKey(ctx, projectID, keyID)
+	if err != nil {
+		resp.Diagnostics.AddError("Error importing project API key",
+			fmt.Sprintf("Could not read project API key %s: %s", keyID, err.Error()))
+		return
+	}
+
+	// Set the imported state with all available information
+	// Note: public_key and secret_key are not available on import since they're only returned at creation
+	resp.Diagnostics.Append(resp.State.Set(ctx, &projectApiKeyResourceModel{
+		ID:                     types.StringValue(keyID),
+		ProjectID:              types.StringValue(projectID),
+		OrganizationPublicKey:  types.StringValue(orgPublicKey),
+		OrganizationPrivateKey: types.StringValue(orgPrivateKey),
+		PublicKey:              types.StringNull(), // Not retrievable after creation
+		SecretKey:              types.StringNull(), // Not retrievable after creation
+	})...)
 }

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -43,6 +44,41 @@ func (r *projectResource) Configure(ctx context.Context, req resource.ConfigureR
 	r.ClientFactory = req.ProviderData.(langfuse.ClientFactory)
 }
 
+// resolveOrgCredentials returns the org credentials to use, implementing the fallback pattern:
+// 1. Use resource-level credentials if provided
+// 2. Fall back to provider-level credentials if available
+// 3. Error if neither is available
+func (r *projectResource) resolveOrgCredentials(
+	ctx context.Context,
+	resourcePublicKey, resourcePrivateKey types.String,
+) (publicKey string, privateKey string, err error) {
+
+	// Check if resource has explicit credentials
+	hasResourceCreds := !resourcePublicKey.IsNull() &&
+		!resourcePublicKey.IsUnknown() &&
+		resourcePublicKey.ValueString() != "" &&
+		!resourcePrivateKey.IsNull() &&
+		!resourcePrivateKey.IsUnknown() &&
+		resourcePrivateKey.ValueString() != ""
+
+	if hasResourceCreds {
+		return resourcePublicKey.ValueString(), resourcePrivateKey.ValueString(), nil
+	}
+
+	// Fall back to provider-level credentials
+	if r.ClientFactory.HasDefaultOrgCredentials() {
+		return r.ClientFactory.GetDefaultOrgPublicKey(),
+			r.ClientFactory.GetDefaultOrgPrivateKey(),
+			nil
+	}
+
+	// Neither available - return error
+	return "", "", fmt.Errorf(
+		"organization credentials required: provide org_public_key and org_private_key " +
+			"either at resource level or configure at provider level",
+	)
+}
+
 func (r *projectResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_project"
 }
@@ -74,17 +110,17 @@ func (r *projectResource) Schema(ctx context.Context, req resource.SchemaRequest
 				},
 			},
 			"organization_public_key": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
-				Description: "Organization public key to authenticate the call.",
+				Description: "Organization public key to authenticate the call. If not provided, uses provider-level org_public_key.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"organization_private_key": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
-				Description: "Organization private key to authenticate the call.",
+				Description: "Organization private key to authenticate the call. If not provided, uses provider-level org_private_key.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -101,6 +137,13 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	// Resolve credentials with fallback
+	publicKey, privateKey, err := r.resolveOrgCredentials(ctx, data.OrganizationPublicKey, data.OrganizationPrivateKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Missing Organization Credentials", err.Error())
+		return
+	}
+
 	metadata := make(map[string]string)
 	if !data.Metadata.IsNull() && !data.Metadata.IsUnknown() {
 		resp.Diagnostics.Append(data.Metadata.ElementsAs(ctx, &metadata, false)...)
@@ -109,7 +152,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 	}
 
-	organizationClient := r.ClientFactory.NewOrganizationClient(data.OrganizationPublicKey.ValueString(), data.OrganizationPrivateKey.ValueString())
+	organizationClient := r.ClientFactory.NewOrganizationClient(publicKey, privateKey)
 	project, err := organizationClient.CreateProject(ctx, &langfuse.CreateProjectRequest{
 		Name:          data.Name.ValueString(),
 		RetentionDays: data.RetentionDays.ValueInt32(),
@@ -138,8 +181,8 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 		RetentionDays:          types.Int32Value(project.RetentionDays),
 		Metadata:               metadataMap,
 		OrganizationID:         types.StringValue(data.OrganizationID.ValueString()),
-		OrganizationPublicKey:  types.StringValue(data.OrganizationPublicKey.ValueString()),
-		OrganizationPrivateKey: types.StringValue(data.OrganizationPrivateKey.ValueString()),
+		OrganizationPublicKey:  types.StringValue(publicKey),
+		OrganizationPrivateKey: types.StringValue(privateKey),
 	})...)
 }
 
@@ -151,7 +194,14 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	organizationClient := r.ClientFactory.NewOrganizationClient(data.OrganizationPublicKey.ValueString(), data.OrganizationPrivateKey.ValueString())
+	// Resolve credentials with fallback
+	publicKey, privateKey, err := r.resolveOrgCredentials(ctx, data.OrganizationPublicKey, data.OrganizationPrivateKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Missing Organization Credentials", err.Error())
+		return
+	}
+
+	organizationClient := r.ClientFactory.NewOrganizationClient(publicKey, privateKey)
 	project, err := organizationClient.GetProject(ctx, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading project", err.Error())
@@ -177,8 +227,8 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		RetentionDays:          data.RetentionDays,
 		Metadata:               metadataMap,
 		OrganizationID:         types.StringValue(data.OrganizationID.ValueString()),
-		OrganizationPublicKey:  types.StringValue(data.OrganizationPublicKey.ValueString()),
-		OrganizationPrivateKey: types.StringValue(data.OrganizationPrivateKey.ValueString()),
+		OrganizationPublicKey:  types.StringValue(publicKey),
+		OrganizationPrivateKey: types.StringValue(privateKey),
 	})...)
 }
 
@@ -197,6 +247,13 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	// Resolve credentials with fallback
+	publicKey, privateKey, err := r.resolveOrgCredentials(ctx, data.OrganizationPublicKey, data.OrganizationPrivateKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Missing Organization Credentials", err.Error())
+		return
+	}
+
 	projectID := currentState.ID.ValueString()
 
 	metadata := make(map[string]string)
@@ -207,7 +264,7 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		}
 	}
 
-	organizationClient := r.ClientFactory.NewOrganizationClient(data.OrganizationPublicKey.ValueString(), data.OrganizationPrivateKey.ValueString())
+	organizationClient := r.ClientFactory.NewOrganizationClient(publicKey, privateKey)
 
 	request := &langfuse.UpdateProjectRequest{
 		Name:          data.Name.ValueString(),
@@ -239,8 +296,8 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		RetentionDays:          data.RetentionDays, // Use from config, not API response
 		Metadata:               metadataMap,
 		OrganizationID:         types.StringValue(data.OrganizationID.ValueString()),
-		OrganizationPublicKey:  types.StringValue(data.OrganizationPublicKey.ValueString()),
-		OrganizationPrivateKey: types.StringValue(data.OrganizationPrivateKey.ValueString()),
+		OrganizationPublicKey:  types.StringValue(publicKey),
+		OrganizationPrivateKey: types.StringValue(privateKey),
 	})...)
 }
 
@@ -252,8 +309,15 @@ func (r *projectResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	organizationClient := r.ClientFactory.NewOrganizationClient(data.OrganizationPublicKey.ValueString(), data.OrganizationPrivateKey.ValueString())
-	err := organizationClient.DeleteProject(ctx, data.ID.ValueString())
+	// Resolve credentials with fallback
+	publicKey, privateKey, err := r.resolveOrgCredentials(ctx, data.OrganizationPublicKey, data.OrganizationPrivateKey)
+	if err != nil {
+		resp.Diagnostics.AddError("Missing Organization Credentials", err.Error())
+		return
+	}
+
+	organizationClient := r.ClientFactory.NewOrganizationClient(publicKey, privateKey)
+	err = organizationClient.DeleteProject(ctx, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting project", err.Error())
 		return
@@ -271,20 +335,44 @@ func (r *projectResource) Delete(ctx context.Context, req resource.DeleteRequest
 }
 
 func (r *projectResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Import format: project_id,organization_id,organization_public_key,organization_private_key
-	// Example: terraform import langfuse_project.example "proj_123,org_456,pk_789,sk_012"
-
 	importParts := strings.Split(req.ID, ",")
-	if len(importParts) != 4 {
+
+	var projectID, organizationID, organizationPublicKey, organizationPrivateKey string
+
+	switch len(importParts) {
+	case 2:
+		// New format: "project_id,organization_id" - use provider credentials
+		projectID = importParts[0]
+		organizationID = importParts[1]
+
+		if !r.ClientFactory.HasDefaultOrgCredentials() {
+			resp.Diagnostics.AddError(
+				"Missing Organization Credentials for Import",
+				"Import format 'project_id,organization_id' requires provider-level org credentials. "+
+					"Either:\n"+
+					"1. Configure provider with org_public_key and org_private_key, or\n"+
+					"2. Use import format: project_id,organization_id,org_public_key,org_private_key",
+			)
+			return
+		}
+
+		organizationPublicKey = r.ClientFactory.GetDefaultOrgPublicKey()
+		organizationPrivateKey = r.ClientFactory.GetDefaultOrgPrivateKey()
+
+	case 4:
+		// Legacy format: "project_id,organization_id,public_key,private_key"
+		projectID = importParts[0]
+		organizationID = importParts[1]
+		organizationPublicKey = importParts[2]
+		organizationPrivateKey = importParts[3]
+
+	default:
 		resp.Diagnostics.AddError("Invalid import format",
-			"Import ID must be in format: project_id,organization_id,organization_public_key,organization_private_key")
+			"Import ID must be in one of these formats:\n"+
+				"1. project_id,organization_id (requires provider-level credentials)\n"+
+				"2. project_id,organization_id,organization_public_key,organization_private_key")
 		return
 	}
-
-	projectID := importParts[0]
-	organizationID := importParts[1]
-	organizationPublicKey := importParts[2]
-	organizationPrivateKey := importParts[3]
 
 	// Get the project details using the provided organization credentials
 	organizationClient := r.ClientFactory.NewOrganizationClient(organizationPublicKey, organizationPrivateKey)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -19,8 +19,10 @@ type langfuseProvider struct {
 }
 
 type langfuseProviderModel struct {
-	Host        types.String `tfsdk:"host"`
-	AdminAPIKey types.String `tfsdk:"admin_api_key"`
+	Host           types.String `tfsdk:"host"`
+	AdminAPIKey    types.String `tfsdk:"admin_api_key"`
+	OrgPublicKey   types.String `tfsdk:"org_public_key"`
+	OrgPrivateKey  types.String `tfsdk:"org_private_key"`
 }
 
 func (p *langfuseProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -39,6 +41,16 @@ func (p *langfuseProvider) Schema(ctx context.Context, req provider.SchemaReques
 				Optional:    true,
 				Sensitive:   true,
 				Description: "Admin API key. Only needed when managing organizations. Can also come from LANGFUSE_ADMIN_KEY.",
+			},
+			"org_public_key": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Organization public key. Used as default for resources that require org-level auth. Can also come from LANGFUSE_ORG_PUBLIC_KEY.",
+			},
+			"org_private_key": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Organization private key. Used as default for resources that require org-level auth. Can also come from LANGFUSE_ORG_PRIVATE_KEY.",
 			},
 		},
 	}
@@ -62,7 +74,19 @@ func (p *langfuseProvider) Configure(ctx context.Context, req provider.Configure
 		apiKey = config.AdminAPIKey.ValueString()
 	}
 
-	clientFactory := langfuse.NewClientFactory(host, apiKey)
+	// Org public key
+	orgPublicKey := os.Getenv("LANGFUSE_ORG_PUBLIC_KEY")
+	if !config.OrgPublicKey.IsNull() && !config.OrgPublicKey.IsUnknown() && config.OrgPublicKey.ValueString() != "" {
+		orgPublicKey = config.OrgPublicKey.ValueString()
+	}
+
+	// Org private key
+	orgPrivateKey := os.Getenv("LANGFUSE_ORG_PRIVATE_KEY")
+	if !config.OrgPrivateKey.IsNull() && !config.OrgPrivateKey.IsUnknown() && config.OrgPrivateKey.ValueString() != "" {
+		orgPrivateKey = config.OrgPrivateKey.ValueString()
+	}
+
+	clientFactory := langfuse.NewClientFactory(host, apiKey, orgPublicKey, orgPrivateKey)
 	resp.DataSourceData = clientFactory
 	resp.ResourceData = clientFactory
 }


### PR DESCRIPTION
The previous ImportState implementation used PassthroughID which doesn't work for this resource since it requires organization credentials to authenticate API calls.

Changes:
- Replace PassthroughID with custom import logic that parses the import ID format: membership_id,organization_public_key,organization_private_key
- Validate credentials by fetching the membership from the API
- Set all state attributes using resp.State.Set() for proper state initialization
- Remove unused path import

Add comprehensive import tests:
- Successful import with all fields verified
- Invalid format with missing parts
- Invalid format with too many parts
- Invalid format with only two parts
- API error handling