### PR TITLE
feat(project_api_key): support API key note

### DIFF
--- a/docs/resources/project_api_key.md
+++ b/docs/resources/project_api_key.md
@@ -21,6 +21,10 @@ description: |-
 - `organization_public_key` (String) Organization public key to authenticate the call.
 - `project_id` (String) The ID of the project the key belongs to.
 
+### Optional
+
+- `note` (String) Optional note for the API key (POST /api/public/projects/{projectId}/apiKeys). Because the Langfuse public API only accepts a note at creation time, changing this attribute forces replacement: the old key is deleted and a new one is created (new id and credentials).
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/internal/langfuse/mocks/mock_organization_client.go
+++ b/internal/langfuse/mocks/mock_organization_client.go
@@ -51,18 +51,18 @@ func (mr *MockOrganizationClientMockRecorder) CreateProject(arg0, arg1 interface
 }
 
 // CreateProjectApiKey mocks base method.
-func (m *MockOrganizationClient) CreateProjectApiKey(arg0 context.Context, arg1 string) (*langfuse.ProjectApiKey, error) {
+func (m *MockOrganizationClient) CreateProjectApiKey(arg0 context.Context, arg1 string, arg2 *langfuse.CreateProjectApiKeyRequest) (*langfuse.ProjectApiKey, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateProjectApiKey", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateProjectApiKey", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*langfuse.ProjectApiKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateProjectApiKey indicates an expected call of CreateProjectApiKey.
-func (mr *MockOrganizationClientMockRecorder) CreateProjectApiKey(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockOrganizationClientMockRecorder) CreateProjectApiKey(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProjectApiKey", reflect.TypeOf((*MockOrganizationClient)(nil).CreateProjectApiKey), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProjectApiKey", reflect.TypeOf((*MockOrganizationClient)(nil).CreateProjectApiKey), arg0, arg1, arg2)
 }
 
 // CreateSCIMUser mocks base method.

--- a/internal/langfuse/organization_client.go
+++ b/internal/langfuse/organization_client.go
@@ -15,9 +15,15 @@ type Project struct {
 }
 
 type ProjectApiKey struct {
-	ID        string `json:"id"`
-	PublicKey string `json:"publicKey"`
-	SecretKey string `json:"secretKey"`
+	ID        string  `json:"id"`
+	PublicKey string  `json:"publicKey"`
+	SecretKey string  `json:"secretKey"`
+	Note      *string `json:"note"`
+}
+
+// CreateProjectApiKeyRequest is the JSON body for POST /api/public/projects/{projectId}/apiKeys.
+type CreateProjectApiKeyRequest struct {
+	Note *string `json:"note,omitempty"`
 }
 
 type CreateProjectRequest struct {
@@ -102,7 +108,7 @@ type OrganizationClient interface {
 	UpdateProject(ctx context.Context, projectID string, request *UpdateProjectRequest) (*Project, error)
 	DeleteProject(ctx context.Context, projectID string) error
 	GetProjectApiKey(ctx context.Context, projectID string, apiKeyID string) (*ProjectApiKey, error)
-	CreateProjectApiKey(ctx context.Context, projectID string) (*ProjectApiKey, error)
+	CreateProjectApiKey(ctx context.Context, projectID string, request *CreateProjectApiKeyRequest) (*ProjectApiKey, error)
 	DeleteProjectApiKey(ctx context.Context, projectID string, apiKeyID string) error
 	ListMemberships(ctx context.Context) ([]OrganizationMembership, error)
 	GetMembership(ctx context.Context, membershipID string) (*OrganizationMembership, error)
@@ -224,8 +230,12 @@ func (c *organizationClientImpl) GetProjectApiKey(ctx context.Context, projectID
 	return nil, fmt.Errorf("cannot find API key with ID %s in project %s", apiKeyID, projectID)
 }
 
-func (c *organizationClientImpl) CreateProjectApiKey(ctx context.Context, projectID string) (*ProjectApiKey, error) {
-	resp, err := c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("api/public/projects/%s/apiKeys", projectID), nil)
+func (c *organizationClientImpl) CreateProjectApiKey(ctx context.Context, projectID string, request *CreateProjectApiKeyRequest) (*ProjectApiKey, error) {
+	var body any = struct{}{}
+	if request != nil {
+		body = request
+	}
+	resp, err := c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("api/public/projects/%s/apiKeys", projectID), body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/project_api_key_resource.go
+++ b/internal/provider/project_api_key_resource.go
@@ -3,12 +3,12 @@ package provider
 import (
 	"context"
 
-	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
 )
 
 var _ resource.Resource = &projectApiKeyResource{}
@@ -22,6 +22,7 @@ type projectApiKeyResourceModel struct {
 	OrganizationPublicKey  types.String `tfsdk:"organization_public_key"`
 	OrganizationPrivateKey types.String `tfsdk:"organization_private_key"`
 	ProjectID              types.String `tfsdk:"project_id"`
+	Note                   types.String `tfsdk:"note"`
 	PublicKey              types.String `tfsdk:"public_key"`
 	SecretKey              types.String `tfsdk:"secret_key"`
 }
@@ -70,6 +71,14 @@ func (r *projectApiKeyResource) Schema(ctx context.Context, req resource.SchemaR
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"note": schema.StringAttribute{
+				Optional: true,
+				Description: "Optional note for the API key (POST /api/public/projects/{projectId}/apiKeys). " +
+					"Because the Langfuse public API only accepts a note at creation time, changing this attribute forces replacement: the old key is deleted and a new one is created (new id and credentials).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			"public_key": schema.StringAttribute{
 				Computed:    true,
 				Sensitive:   true,
@@ -101,7 +110,8 @@ func (r *projectApiKeyResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	organizationClient := r.ClientFactory.NewOrganizationClient(data.OrganizationPublicKey.ValueString(), data.OrganizationPrivateKey.ValueString())
-	projectApiKey, err := organizationClient.CreateProjectApiKey(ctx, data.ProjectID.ValueString())
+	createReq := planNoteToCreateRequest(data.Note)
+	projectApiKey, err := organizationClient.CreateProjectApiKey(ctx, data.ProjectID.ValueString(), createReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating project API key", err.Error())
 		return
@@ -112,6 +122,7 @@ func (r *projectApiKeyResource) Create(ctx context.Context, req resource.CreateR
 		OrganizationPublicKey:  types.StringValue(data.OrganizationPublicKey.ValueString()),
 		OrganizationPrivateKey: types.StringValue(data.OrganizationPrivateKey.ValueString()),
 		ProjectID:              types.StringValue(data.ProjectID.ValueString()),
+		Note:                   projectApiKeyNoteToTF(projectApiKey.Note),
 		PublicKey:              types.StringValue(projectApiKey.PublicKey),
 		SecretKey:              types.StringValue(projectApiKey.SecretKey),
 	})...)
@@ -125,11 +136,13 @@ func (r *projectApiKeyResource) Read(ctx context.Context, req resource.ReadReque
 	}
 
 	organizationClient := r.ClientFactory.NewOrganizationClient(data.OrganizationPublicKey.ValueString(), data.OrganizationPrivateKey.ValueString())
-	_, err := organizationClient.GetProjectApiKey(ctx, data.ProjectID.ValueString(), data.ID.ValueString())
+	key, err := organizationClient.GetProjectApiKey(ctx, data.ProjectID.ValueString(), data.ID.ValueString())
 	if err != nil {
 		resp.State.RemoveResource(ctx)
 		return
 	}
+
+	data.Note = projectApiKeyNoteToTF(key.Note)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -154,4 +167,19 @@ func (r *projectApiKeyResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &projectApiKeyResourceModel{})...)
+}
+
+func projectApiKeyNoteToTF(note *string) types.String {
+	if note == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*note)
+}
+
+func planNoteToCreateRequest(note types.String) *langfuse.CreateProjectApiKeyRequest {
+	if note.IsUnknown() || note.IsNull() {
+		return nil
+	}
+	s := note.ValueString()
+	return &langfuse.CreateProjectApiKeyRequest{Note: &s}
 }

--- a/internal/provider/project_api_key_resource_unit_test.go
+++ b/internal/provider/project_api_key_resource_unit_test.go
@@ -104,13 +104,14 @@ func TestProjectApiKeyResourceCRUD(t *testing.T) {
 
 	var createResp resource.CreateResponse
 	t.Run("Create", func(t *testing.T) {
-		clientFactory.OrganizationClient.EXPECT().CreateProjectApiKey(ctx, projectID).Return(&langfuse.ProjectApiKey{ID: projectApiKeyID, PublicKey: publicKey, SecretKey: privateKey}, nil)
+		clientFactory.OrganizationClient.EXPECT().CreateProjectApiKey(ctx, projectID, nil).Return(&langfuse.ProjectApiKey{ID: projectApiKeyID, PublicKey: publicKey, SecretKey: privateKey}, nil)
 
 		createConfig := tfsdk.Config{Raw: buildApiKeyObjectValue(map[string]tftypes.Value{
 			"id":                       tftypes.NewValue(tftypes.String, nil),
 			"project_id":               tftypes.NewValue(tftypes.String, projectID),
 			"organization_public_key":  tftypes.NewValue(tftypes.String, publicKey),
 			"organization_private_key": tftypes.NewValue(tftypes.String, privateKey),
+			"note":                     tftypes.NewValue(tftypes.String, nil),
 			"public_key":               tftypes.NewValue(tftypes.String, nil),
 			"secret_key":               tftypes.NewValue(tftypes.String, nil),
 		}), Schema: resourceSchema}
@@ -153,11 +154,13 @@ func buildApiKeyObjectValue(values map[string]tftypes.Value) tftypes.Value {
 				"organization_public_key":  tftypes.String,
 				"organization_private_key": tftypes.String,
 				"project_id":               tftypes.String,
+				"note":                     tftypes.String,
 				"public_key":               tftypes.String,
 				"secret_key":               tftypes.String,
 			},
 			OptionalAttributes: map[string]struct{}{
 				"id":         {},
+				"note":       {},
 				"public_key": {},
 				"secret_key": {},
 			},

--- a/internal/provider/provider_acceptance_test.go
+++ b/internal/provider/provider_acceptance_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -90,11 +91,18 @@ func TestAccLangfuseWorkflow(t *testing.T) {
 					resource.TestCheckResourceAttrSet("langfuse_project_api_key.test", "public_key"),
 					resource.TestCheckResourceAttrSet("langfuse_project_api_key.test", "secret_key"),
 					resource.TestCheckResourceAttrSet("langfuse_project_api_key.test", "project_id"),
+					resource.TestCheckResourceAttr("langfuse_project_api_key.test", "note", "acceptance-workflow"),
 				),
 			},
 			// Step 5: Update resources with metadata changes (test updates work correctly)
 			{
 				Config: testAccLangfuseWorkflowConfig_Step5(orgName, projectName+"updated"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						// Note unchanged; project API key must not be replaced when only project/org metadata changes.
+						plancheck.ExpectResourceAction("langfuse_project_api_key.test", plancheck.ResourceActionNoop),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Organization unchanged but metadata updated
 					resource.TestCheckResourceAttr("langfuse_organization.test", "name", orgName),
@@ -110,6 +118,7 @@ func TestAccLangfuseWorkflow(t *testing.T) {
 					// API keys still work
 					resource.TestCheckResourceAttrSet("langfuse_organization_api_key.test", "public_key"),
 					resource.TestCheckResourceAttrSet("langfuse_project_api_key.test", "public_key"),
+					resource.TestCheckResourceAttr("langfuse_project_api_key.test", "note", "acceptance-workflow"),
 				),
 			},
 			// Step 6: Explicit cleanup in dependency order to avoid cleanup issues
@@ -241,6 +250,7 @@ resource "langfuse_project_api_key" "test" {
   project_id               = langfuse_project.test.id
   organization_public_key  = langfuse_organization_api_key.test.public_key
   organization_private_key = langfuse_organization_api_key.test.secret_key
+  note                     = "acceptance-workflow"
 }
 `, host, adminKey, orgName, projectName)
 }
@@ -285,6 +295,7 @@ resource "langfuse_project_api_key" "test" {
   project_id               = langfuse_project.test.id
   organization_public_key  = langfuse_organization_api_key.test.public_key
   organization_private_key = langfuse_organization_api_key.test.secret_key
+  note                     = "acceptance-workflow"
 }
 `, host, adminKey, orgName, projectName)
 }
@@ -468,6 +479,86 @@ resource "langfuse_project" "import_test" {
   }
 }
 `, host, adminKey, orgName, projectName)
+}
+
+// TestAccLangfuseProjectApiKeyNoteReplace checks that changing note plans replacement (RequiresReplace),
+// since the Langfuse API only accepts note on create.
+func TestAccLangfuseProjectApiKeyNoteReplace(t *testing.T) {
+	if os.Getenv("TF_ACC") != "1" {
+		t.Skip("TF_ACC not set - skipping acceptance test")
+	}
+
+	testAccPreCheck(t)
+
+	orgName := fmt.Sprintf("note-replace-org-%d", rand.Intn(1000000))
+	projectName := fmt.Sprintf("note-replace-proj-%d", rand.Intn(1000000))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckLangfuseResourcesDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectApiKeyNoteConfig(orgName, projectName, "note-before"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("langfuse_project_api_key.note_test", "note", "note-before"),
+					resource.TestCheckResourceAttrSet("langfuse_project_api_key.note_test", "id"),
+					resource.TestCheckResourceAttrSet("langfuse_project_api_key.note_test", "public_key"),
+					resource.TestCheckResourceAttrSet("langfuse_project_api_key.note_test", "secret_key"),
+				),
+			},
+			{
+				Config: testAccProjectApiKeyNoteConfig(orgName, projectName, "note-after"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("langfuse_project_api_key.note_test", plancheck.ResourceActionReplace),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("langfuse_project_api_key.note_test", plancheck.ResourceActionNoop),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("langfuse_project_api_key.note_test", "note", "note-after"),
+					resource.TestCheckResourceAttrSet("langfuse_project_api_key.note_test", "id"),
+					resource.TestCheckResourceAttrSet("langfuse_project_api_key.note_test", "public_key"),
+					resource.TestCheckResourceAttrSet("langfuse_project_api_key.note_test", "secret_key"),
+				),
+			},
+		},
+	})
+}
+
+func testAccProjectApiKeyNoteConfig(orgName, projectName, projectKeyNote string) string {
+	host := os.Getenv("LANGFUSE_HOST")
+	adminKey := os.Getenv("LANGFUSE_ADMIN_KEY")
+
+	return fmt.Sprintf(`
+provider "langfuse" {
+  host          = "%s"
+  admin_api_key = "%s"
+}
+
+resource "langfuse_organization" "note_test" {
+  name = "%s"
+}
+
+resource "langfuse_organization_api_key" "note_test" {
+  organization_id = langfuse_organization.note_test.id
+}
+
+resource "langfuse_project" "note_test" {
+  name                     = "%s"
+  organization_id          = langfuse_organization.note_test.id
+  organization_public_key  = langfuse_organization_api_key.note_test.public_key
+  organization_private_key = langfuse_organization_api_key.note_test.secret_key
+}
+
+resource "langfuse_project_api_key" "note_test" {
+  project_id               = langfuse_project.note_test.id
+  organization_public_key  = langfuse_organization_api_key.note_test.public_key
+  organization_private_key = langfuse_organization_api_key.note_test.secret_key
+  note                     = "%s"
+}
+`, host, adminKey, orgName, projectName, projectKeyNote)
 }
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){


### PR DESCRIPTION
- Send optional note in POST .../apiKeys body
- Refresh note from GET list in Read
- Use RequiresReplace when note changes (no public update API)