### PR TITLE
feat: add langfuse_user data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,37 @@ output "project_secret_key" {
 }
 ```
 
+## Data Sources
+
+### `langfuse_organization`
+
+Reads an existing Langfuse organization by its ID or name. Exactly one of `id` or `name` must be specified.
+
+#### Arguments
+
+- `id` (String, Optional) - The unique identifier of the organization. Exactly one of `id` or `name` must be specified.
+- `name` (String, Optional) - The display name of the organization. Exactly one of `id` or `name` must be specified.
+
+#### Attributes
+
+- `id` (String) - The unique identifier of the organization
+- `name` (String) - The display name of the organization
+- `metadata` (Map of String) - Metadata for the organization as key-value pairs
+
+#### Example Usage
+
+```hcl
+# Look up by ID
+data "langfuse_organization" "by_id" {
+  id = "org-123"
+}
+
+# Look up by name
+data "langfuse_organization" "by_name" {
+  name = "My Organization"
+}
+```
+
 ## Resources
 
 ### `langfuse_organization`

--- a/internal/langfuse/mocks/mock_organization_client.go
+++ b/internal/langfuse/mocks/mock_organization_client.go
@@ -153,6 +153,21 @@ func (mr *MockOrganizationClientMockRecorder) GetProjectApiKey(arg0, arg1, arg2 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectApiKey", reflect.TypeOf((*MockOrganizationClient)(nil).GetProjectApiKey), arg0, arg1, arg2)
 }
 
+// ListLlmConnections mocks base method.
+func (m *MockOrganizationClient) ListLlmConnections(arg0 context.Context, arg1, arg2 int) (*langfuse.PaginatedLlmConnections, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListLlmConnections", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*langfuse.PaginatedLlmConnections)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListLlmConnections indicates an expected call of ListLlmConnections.
+func (mr *MockOrganizationClientMockRecorder) ListLlmConnections(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLlmConnections", reflect.TypeOf((*MockOrganizationClient)(nil).ListLlmConnections), arg0, arg1, arg2)
+}
+
 // ListMemberships mocks base method.
 func (m *MockOrganizationClient) ListMemberships(arg0 context.Context) ([]langfuse.OrganizationMembership, error) {
 	m.ctrl.T.Helper()
@@ -225,4 +240,19 @@ func (m *MockOrganizationClient) UpdateProject(arg0 context.Context, arg1 string
 func (mr *MockOrganizationClientMockRecorder) UpdateProject(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProject", reflect.TypeOf((*MockOrganizationClient)(nil).UpdateProject), arg0, arg1, arg2)
+}
+
+// UpsertLlmConnection mocks base method.
+func (m *MockOrganizationClient) UpsertLlmConnection(arg0 context.Context, arg1 *langfuse.UpsertLlmConnectionRequest) (*langfuse.LlmConnection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertLlmConnection", arg0, arg1)
+	ret0, _ := ret[0].(*langfuse.LlmConnection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpsertLlmConnection indicates an expected call of UpsertLlmConnection.
+func (mr *MockOrganizationClientMockRecorder) UpsertLlmConnection(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertLlmConnection", reflect.TypeOf((*MockOrganizationClient)(nil).UpsertLlmConnection), arg0, arg1)
 }

--- a/internal/langfuse/mocks/mock_organization_client.go
+++ b/internal/langfuse/mocks/mock_organization_client.go
@@ -65,6 +65,36 @@ func (mr *MockOrganizationClientMockRecorder) CreateProjectApiKey(arg0, arg1 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProjectApiKey", reflect.TypeOf((*MockOrganizationClient)(nil).CreateProjectApiKey), arg0, arg1)
 }
 
+// FindSCIMUserByEmail mocks base method.
+func (m *MockOrganizationClient) FindSCIMUserByEmail(arg0 context.Context, arg1 string) (*langfuse.SCIMUserResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindSCIMUserByEmail", arg0, arg1)
+	ret0, _ := ret[0].(*langfuse.SCIMUserResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindSCIMUserByEmail indicates an expected call of FindSCIMUserByEmail.
+func (mr *MockOrganizationClientMockRecorder) FindSCIMUserByEmail(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindSCIMUserByEmail", reflect.TypeOf((*MockOrganizationClient)(nil).FindSCIMUserByEmail), arg0, arg1)
+}
+
+// GetSCIMUser mocks base method.
+func (m *MockOrganizationClient) GetSCIMUser(arg0 context.Context, arg1 string) (*langfuse.SCIMUserResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSCIMUser", arg0, arg1)
+	ret0, _ := ret[0].(*langfuse.SCIMUserResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSCIMUser indicates an expected call of GetSCIMUser.
+func (mr *MockOrganizationClientMockRecorder) GetSCIMUser(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSCIMUser", reflect.TypeOf((*MockOrganizationClient)(nil).GetSCIMUser), arg0, arg1)
+}
+
 // CreateSCIMUser mocks base method.
 func (m *MockOrganizationClient) CreateSCIMUser(arg0 context.Context, arg1 *langfuse.SCIMUserRequest) (*langfuse.SCIMUserResponse, error) {
 	m.ctrl.T.Helper()

--- a/internal/langfuse/organization_client.go
+++ b/internal/langfuse/organization_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -115,6 +116,11 @@ type SCIMUserResponse struct {
 	Active bool `json:"active"`
 }
 
+type SCIMListResponse struct {
+	TotalResults int                `json:"totalResults"`
+	Resources    []SCIMUserResponse `json:"Resources"`
+}
+
 type UpdateMembershipRequest struct {
 	UserID string `json:"userId,omitempty"` // User ID from SCIM
 	Email  string `json:"email,omitempty"`  // Or email
@@ -148,6 +154,8 @@ type OrganizationClient interface {
 	UpdateMembership(ctx context.Context, membershipID string, request *UpdateMembershipRequest) (*OrganizationMembership, error)
 	RemoveMember(ctx context.Context, membershipID string) error
 	CreateSCIMUser(ctx context.Context, request *SCIMUserRequest) (*SCIMUserResponse, error)
+	GetSCIMUser(ctx context.Context, userID string) (*SCIMUserResponse, error)
+	FindSCIMUserByEmail(ctx context.Context, email string) (*SCIMUserResponse, error)
 }
 
 type organizationClientImpl struct {
@@ -423,6 +431,41 @@ func (c *organizationClientImpl) RemoveMember(ctx context.Context, membershipID 
 	}
 
 	return nil
+}
+
+func (c *organizationClientImpl) GetSCIMUser(ctx context.Context, userID string) (*SCIMUserResponse, error) {
+	resp, err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("api/public/scim/Users/%s", userID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get SCIM user: %w", err)
+	}
+
+	var user SCIMUserResponse
+	if err := decodeResponse(resp, &user); err != nil {
+		return nil, fmt.Errorf("failed to decode SCIM user response: %w", err)
+	}
+
+	return &user, nil
+}
+
+func (c *organizationClientImpl) FindSCIMUserByEmail(ctx context.Context, email string) (*SCIMUserResponse, error) {
+	filter := fmt.Sprintf("userName eq \"%s\"", email)
+	path := fmt.Sprintf("api/public/scim/Users?filter=%s", url.QueryEscape(filter))
+
+	resp, err := c.makeRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find SCIM user: %w", err)
+	}
+
+	var list SCIMListResponse
+	if err := decodeResponse(resp, &list); err != nil {
+		return nil, fmt.Errorf("failed to decode SCIM user list response: %w", err)
+	}
+
+	if list.TotalResults == 0 || len(list.Resources) == 0 {
+		return nil, fmt.Errorf("cannot find user with email %q", email)
+	}
+
+	return &list.Resources[0], nil
 }
 
 func (c *organizationClientImpl) CreateSCIMUser(ctx context.Context, request *SCIMUserRequest) (*SCIMUserResponse, error) {

--- a/internal/langfuse/organization_client.go
+++ b/internal/langfuse/organization_client.go
@@ -20,6 +20,43 @@ type ProjectApiKey struct {
 	SecretKey string `json:"secretKey"`
 }
 
+type MetaResponse struct {
+	Page       int `json:"page"`
+	Limit      int `json:"limit"`
+	TotalItems int `json:"totalItems"`
+	TotalPages int `json:"totalPages"`
+}
+
+type LlmConnection struct {
+	ID                string         `json:"id"`
+	Provider          string         `json:"provider"`
+	Adapter           string         `json:"adapter"`
+	DisplaySecretKey  string         `json:"displaySecretKey"`
+	BaseURL           *string        `json:"baseURL"`
+	CustomModels      []string       `json:"customModels"`
+	WithDefaultModels bool           `json:"withDefaultModels"`
+	ExtraHeaderKeys   []string       `json:"extraHeaderKeys"`
+	Config            map[string]any `json:"config"`
+	CreatedAt         string         `json:"createdAt"`
+	UpdatedAt         string         `json:"updatedAt"`
+}
+
+type PaginatedLlmConnections struct {
+	Data []LlmConnection `json:"data"`
+	Meta MetaResponse    `json:"meta"`
+}
+
+type UpsertLlmConnectionRequest struct {
+	Provider          string            `json:"provider"`
+	Adapter           string            `json:"adapter"`
+	SecretKey         string            `json:"secretKey"`
+	BaseURL           *string           `json:"baseURL,omitempty"`
+	CustomModels      []string          `json:"customModels,omitempty"`
+	WithDefaultModels *bool             `json:"withDefaultModels,omitempty"`
+	ExtraHeaders      map[string]string `json:"extraHeaders,omitempty"`
+	Config            map[string]any    `json:"config,omitempty"`
+}
+
 type CreateProjectRequest struct {
 	Name          string            `json:"name"`
 	RetentionDays int32             `json:"retention"`
@@ -104,6 +141,8 @@ type OrganizationClient interface {
 	GetProjectApiKey(ctx context.Context, projectID string, apiKeyID string) (*ProjectApiKey, error)
 	CreateProjectApiKey(ctx context.Context, projectID string) (*ProjectApiKey, error)
 	DeleteProjectApiKey(ctx context.Context, projectID string, apiKeyID string) error
+	ListLlmConnections(ctx context.Context, page, limit int) (*PaginatedLlmConnections, error)
+	UpsertLlmConnection(ctx context.Context, request *UpsertLlmConnectionRequest) (*LlmConnection, error)
 	ListMemberships(ctx context.Context) ([]OrganizationMembership, error)
 	GetMembership(ctx context.Context, membershipID string) (*OrganizationMembership, error)
 	UpdateMembership(ctx context.Context, membershipID string, request *UpdateMembershipRequest) (*OrganizationMembership, error)
@@ -254,6 +293,46 @@ func (c *organizationClientImpl) DeleteProjectApiKey(ctx context.Context, projec
 	return nil
 }
 
+func (c *organizationClientImpl) ListLlmConnections(ctx context.Context, page, limit int) (*PaginatedLlmConnections, error) {
+	path := "api/public/llm-connections"
+	params := make([]string, 0, 2)
+	if page > 0 {
+		params = append(params, fmt.Sprintf("page=%d", page))
+	}
+	if limit > 0 {
+		params = append(params, fmt.Sprintf("limit=%d", limit))
+	}
+	if len(params) > 0 {
+		path += "?" + strings.Join(params, "&")
+	}
+
+	resp, err := c.makeRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var out PaginatedLlmConnections
+	if err := decodeResponse(resp, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *organizationClientImpl) UpsertLlmConnection(ctx context.Context, request *UpsertLlmConnectionRequest) (*LlmConnection, error) {
+	resp, err := c.makeRequest(ctx, http.MethodPut, "api/public/llm-connections", request)
+	if err != nil {
+		return nil, err
+	}
+
+	var conn LlmConnection
+	if err := decodeResponse(resp, &conn); err != nil {
+		return nil, err
+	}
+
+	return &conn, nil
+}
+
 func (c *organizationClientImpl) ListMemberships(ctx context.Context) ([]OrganizationMembership, error) {
 	resp, err := c.makeRequest(ctx, http.MethodGet, "api/public/organizations/memberships", nil)
 	if err != nil {
@@ -296,7 +375,7 @@ func (c *organizationClientImpl) UpdateMembership(ctx context.Context, membershi
 	if userIDToUpdate == "" {
 		userIDToUpdate = currentMembership.UserID
 	}
-	
+
 	updateRequest := UpdateMembershipRequest{
 		UserID: userIDToUpdate,
 		Role:   request.Role,
@@ -327,7 +406,7 @@ func (c *organizationClientImpl) RemoveMember(ctx context.Context, membershipID 
 	}{
 		UserID: membershipID,
 	}
-	
+
 	resp, err := c.makeRequest(ctx, http.MethodDelete, "api/public/organizations/memberships", deleteRequest)
 	if err != nil {
 		return err
@@ -337,7 +416,7 @@ func (c *organizationClientImpl) RemoveMember(ctx context.Context, membershipID 
 	if err := decodeResponse(resp, &removeMemberResp); err != nil {
 		return err
 	}
-	
+
 	// API returns success: false but with a success message, so we check the message too
 	if !removeMemberResp.Success && !strings.Contains(strings.ToLower(removeMemberResp.Message), "deleted") && !strings.Contains(strings.ToLower(removeMemberResp.Message), "removed") {
 		return fmt.Errorf("failed to remove member with ID %s: %s", membershipID, removeMemberResp.Message)

--- a/internal/langfuse/utils.go
+++ b/internal/langfuse/utils.go
@@ -35,11 +35,22 @@ func decodeResponse(resp *http.Response, target any) error {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("request failed with status code %d, response body: %s", resp.StatusCode, string(body))
 	}
+
+	// Some endpoints (e.g. DELETE) may return an empty body.
+	if target == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
-	if err = json.Unmarshal(body, &target); err != nil {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+
+	if err = json.Unmarshal(body, target); err != nil {
 		return fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 

--- a/internal/provider/llm_connection_resource.go
+++ b/internal/provider/llm_connection_resource.go
@@ -1,0 +1,454 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
+)
+
+var _ resource.Resource = &llmConnectionResource{}
+var _ resource.ResourceWithImportState = &llmConnectionResource{}
+
+func NewLlmConnectionResource() resource.Resource {
+	return &llmConnectionResource{}
+}
+
+type llmConnectionResourceModel struct {
+	ID               types.String `tfsdk:"id"`
+	ProjectPublicKey types.String `tfsdk:"project_public_key"`
+	ProjectSecretKey types.String `tfsdk:"project_secret_key"`
+
+	ProviderName types.String `tfsdk:"provider_name"`
+	Adapter      types.String `tfsdk:"adapter"`
+
+	SecretKey types.String `tfsdk:"secret_key"`
+
+	BaseURL           types.String `tfsdk:"base_url"`
+	CustomModels      types.List   `tfsdk:"custom_models"`
+	WithDefaultModels types.Bool   `tfsdk:"with_default_models"`
+	ExtraHeaders      types.Map    `tfsdk:"extra_headers"`
+	ConfigJSON        types.String `tfsdk:"config_json"`
+
+	DisplaySecretKey types.String `tfsdk:"display_secret_key"`
+	ExtraHeaderKeys  types.List   `tfsdk:"extra_header_keys"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	UpdatedAt        types.String `tfsdk:"updated_at"`
+}
+
+type llmConnectionResource struct {
+	ClientFactory langfuse.ClientFactory
+}
+
+func (r *llmConnectionResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	r.ClientFactory = req.ProviderData.(langfuse.ClientFactory)
+}
+
+func (r *llmConnectionResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_llm_connection"
+}
+
+func (r *llmConnectionResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"project_public_key": schema.StringAttribute{
+				Required:    true,
+				Sensitive:   true,
+				Description: "Project public key to authenticate the call.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"project_secret_key": schema.StringAttribute{
+				Required:    true,
+				Sensitive:   true,
+				Description: "Project secret key to authenticate the call.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"provider_name": schema.StringAttribute{
+				Required:    true,
+				Description: "Provider name (e.g., 'openai', 'my-gateway'). Must be unique in project.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"adapter": schema.StringAttribute{
+				Required:    true,
+				Description: "Adapter used to interface with the LLM (e.g., openai, anthropic, azure, bedrock).",
+			},
+			"secret_key": schema.StringAttribute{
+				Required:    true,
+				Sensitive:   true,
+				Description: "Secret key for the LLM API. Not returned by Langfuse after upsert.",
+				PlanModifiers: []planmodifier.String{
+					// Keep the value that is already in state because Read() will never be able to fetch it.
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"base_url": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Custom base URL for the LLM API.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"custom_models": schema.ListAttribute{
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "List of custom model names available for this connection.",
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"with_default_models": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether to include default models for this adapter. Default is true.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"extra_headers": schema.MapAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				ElementType: types.StringType,
+				Description: "Extra headers to send with requests. Values are not returned by Langfuse after upsert.",
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"config_json": schema.StringAttribute{
+				Optional:    true,
+				Description: "Adapter-specific configuration as a JSON object (e.g. for bedrock: {\"region\":\"us-east-1\"}).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"display_secret_key": schema.StringAttribute{
+				Computed:    true,
+				Description: "Masked version of the secret key for display purposes.",
+			},
+			"extra_header_keys": schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "Keys of extra headers sent with requests (values excluded for security).",
+			},
+			"created_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp when the connection was created.",
+			},
+			"updated_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp when the connection was last updated.",
+			},
+		},
+	}
+}
+
+func (r *llmConnectionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data llmConnectionResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn, err := r.upsert(ctx, &data, &resp.Diagnostics)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating LLM connection", err.Error())
+		return
+	}
+
+	state, diags := llmConnectionStateFromAPI(ctx, conn, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *llmConnectionResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data llmConnectionResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	organizationClient := r.ClientFactory.NewOrganizationClient(data.ProjectPublicKey.ValueString(), data.ProjectSecretKey.ValueString())
+	conn, err := findLlmConnectionByProvider(ctx, organizationClient, data.ProviderName.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading LLM connection", err.Error())
+		return
+	}
+	if conn == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state, diags := llmConnectionStateFromAPI(ctx, conn, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *llmConnectionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data llmConnectionResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn, err := r.upsert(ctx, &data, &resp.Diagnostics)
+	if err != nil {
+		resp.Diagnostics.AddError("Error updating LLM connection", err.Error())
+		return
+	}
+
+	state, diags := llmConnectionStateFromAPI(ctx, conn, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *llmConnectionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.Diagnostics.AddWarning(
+		"LLM connection deletion skipped",
+		"The Langfuse API does not expose an endpoint to delete LLM connections. The resource will be removed from state but remain in Langfuse.",
+	)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, emptyLlmConnectionState())...)
+}
+
+func (r *llmConnectionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Import format: provider,project_public_key,project_secret_key,secret_key
+	// Example: terraform import langfuse_llm_connection.example "openai,pk_123,sk_456,OPENAI_KEY"
+
+	importParts := strings.Split(req.ID, ",")
+	if len(importParts) != 4 {
+		resp.Diagnostics.AddError("Invalid import format", "Import ID must be in format: provider,project_public_key,project_secret_key,secret_key")
+		return
+	}
+
+	provider := importParts[0]
+	projectPublicKey := importParts[1]
+	projectSecretKey := importParts[2]
+	secretKey := importParts[3]
+
+	organizationClient := r.ClientFactory.NewOrganizationClient(projectPublicKey, projectSecretKey)
+	conn, err := findLlmConnectionByProvider(ctx, organizationClient, provider)
+	if err != nil {
+		resp.Diagnostics.AddError("Error importing LLM connection", err.Error())
+		return
+	}
+	if conn == nil {
+		resp.Diagnostics.AddError("Error importing LLM connection", fmt.Sprintf("Could not find LLM connection with provider %q", provider))
+		return
+	}
+
+	state := llmConnectionResourceModel{
+		ID:               types.StringValue(conn.ID),
+		ProjectPublicKey: types.StringValue(projectPublicKey),
+		ProjectSecretKey: types.StringValue(projectSecretKey),
+		ProviderName:     types.StringValue(conn.Provider),
+		Adapter:          types.StringValue(conn.Adapter),
+		SecretKey:        types.StringValue(secretKey),
+		ExtraHeaders:     types.MapNull(types.StringType),
+		ConfigJSON:       types.StringNull(),
+	}
+
+	fullState, diags := llmConnectionStateFromAPI(ctx, conn, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &fullState)...)
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), resource.ImportStateRequest{ID: conn.ID}, resp)
+}
+
+func (r *llmConnectionResource) upsert(ctx context.Context, data *llmConnectionResourceModel, diags *diag.Diagnostics) (*langfuse.LlmConnection, error) {
+	var baseURL *string
+	if !data.BaseURL.IsNull() && !data.BaseURL.IsUnknown() && data.BaseURL.ValueString() != "" {
+		v := data.BaseURL.ValueString()
+		baseURL = &v
+	}
+
+	var customModels []string
+	if !data.CustomModels.IsNull() && !data.CustomModels.IsUnknown() {
+		diags.Append(data.CustomModels.ElementsAs(ctx, &customModels, false)...)
+		if diags.HasError() {
+			return nil, fmt.Errorf("invalid custom_models")
+		}
+	}
+
+	var withDefaultModels *bool
+	if !data.WithDefaultModels.IsNull() && !data.WithDefaultModels.IsUnknown() {
+		v := data.WithDefaultModels.ValueBool()
+		withDefaultModels = &v
+	}
+
+	extraHeaders := make(map[string]string)
+	if !data.ExtraHeaders.IsNull() && !data.ExtraHeaders.IsUnknown() {
+		diags.Append(data.ExtraHeaders.ElementsAs(ctx, &extraHeaders, false)...)
+		if diags.HasError() {
+			return nil, fmt.Errorf("invalid extra_headers")
+		}
+	}
+
+	var config map[string]any
+	if !data.ConfigJSON.IsNull() && !data.ConfigJSON.IsUnknown() && data.ConfigJSON.ValueString() != "" {
+		raw := []byte(data.ConfigJSON.ValueString())
+		if !json.Valid(raw) {
+			return nil, fmt.Errorf("config_json must be valid JSON")
+		}
+		var decoded any
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			return nil, fmt.Errorf("config_json must be valid JSON: %w", err)
+		}
+		m, ok := decoded.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("config_json must be a JSON object")
+		}
+		config = m
+	}
+
+	upsertReq := &langfuse.UpsertLlmConnectionRequest{
+		Provider:          data.ProviderName.ValueString(),
+		Adapter:           data.Adapter.ValueString(),
+		SecretKey:         data.SecretKey.ValueString(),
+		BaseURL:           baseURL,
+		CustomModels:      customModels,
+		WithDefaultModels: withDefaultModels,
+	}
+	if len(extraHeaders) > 0 {
+		upsertReq.ExtraHeaders = extraHeaders
+	}
+	if config != nil {
+		upsertReq.Config = config
+	}
+
+	organizationClient := r.ClientFactory.NewOrganizationClient(data.ProjectPublicKey.ValueString(), data.ProjectSecretKey.ValueString())
+	return organizationClient.UpsertLlmConnection(ctx, upsertReq)
+}
+
+func findLlmConnectionByProvider(ctx context.Context, client langfuse.OrganizationClient, provider string) (*langfuse.LlmConnection, error) {
+	page := 1
+	limit := 100
+	for {
+		resp, err := client.ListLlmConnections(ctx, page, limit)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range resp.Data {
+			if c.Provider == provider {
+				conn := c
+				return &conn, nil
+			}
+		}
+		if page >= resp.Meta.TotalPages {
+			return nil, nil
+		}
+		page++
+	}
+}
+
+func llmConnectionStateFromAPI(ctx context.Context, conn *langfuse.LlmConnection, prior *llmConnectionResourceModel) (llmConnectionResourceModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	state := *prior
+	state.ID = types.StringValue(conn.ID)
+	state.ProviderName = types.StringValue(conn.Provider)
+	state.Adapter = types.StringValue(conn.Adapter)
+	state.DisplaySecretKey = types.StringValue(conn.DisplaySecretKey)
+	state.CreatedAt = types.StringValue(conn.CreatedAt)
+	state.UpdatedAt = types.StringValue(conn.UpdatedAt)
+
+	if conn.BaseURL != nil {
+		state.BaseURL = types.StringValue(*conn.BaseURL)
+	} else {
+		state.BaseURL = types.StringNull()
+	}
+
+	customModels, d := types.ListValueFrom(ctx, types.StringType, conn.CustomModels)
+	diags.Append(d...)
+	if diags.HasError() {
+		return llmConnectionResourceModel{}, diags
+	}
+	state.CustomModels = customModels
+
+	state.WithDefaultModels = types.BoolValue(conn.WithDefaultModels)
+
+	extraHeaderKeys, d := types.ListValueFrom(ctx, types.StringType, conn.ExtraHeaderKeys)
+	diags.Append(d...)
+	if diags.HasError() {
+		return llmConnectionResourceModel{}, diags
+	}
+	state.ExtraHeaderKeys = extraHeaderKeys
+
+	// Secrets are not returned by the API; keep prior values.
+	if state.SecretKey.IsNull() {
+		state.SecretKey = prior.SecretKey
+	}
+	if state.ExtraHeaders.IsNull() {
+		state.ExtraHeaders = prior.ExtraHeaders
+	}
+	if state.ConfigJSON.IsNull() {
+		state.ConfigJSON = prior.ConfigJSON
+	}
+
+	return state, diags
+}
+
+func emptyLlmConnectionState() *llmConnectionResourceModel {
+	return &llmConnectionResourceModel{
+		ID:                types.StringValue(""),
+		ProjectPublicKey:  types.StringValue(""),
+		ProjectSecretKey:  types.StringValue(""),
+		ProviderName:      types.StringValue(""),
+		Adapter:           types.StringValue(""),
+		SecretKey:         types.StringValue(""),
+		BaseURL:           types.StringNull(),
+		CustomModels:      types.ListNull(types.StringType),
+		WithDefaultModels: types.BoolNull(),
+		ExtraHeaders:      types.MapNull(types.StringType),
+		ConfigJSON:        types.StringNull(),
+		DisplaySecretKey:  types.StringValue(""),
+		ExtraHeaderKeys:   types.ListNull(types.StringType),
+		CreatedAt:         types.StringValue(""),
+		UpdatedAt:         types.StringValue(""),
+	}
+}

--- a/internal/provider/llm_connection_resource_unit_test.go
+++ b/internal/provider/llm_connection_resource_unit_test.go
@@ -1,0 +1,209 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse/mocks"
+)
+
+func TestLlmConnectionResourceMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := NewLlmConnectionResource()
+
+	var resp resource.MetadataResponse
+	r.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: "langfuse"}, &resp)
+
+	if resp.TypeName != "langfuse_llm_connection" {
+		t.Fatalf("unexpected type name. got %q, want %q", resp.TypeName, "langfuse_llm_connection")
+	}
+}
+
+func TestLlmConnectionResourceSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := NewLlmConnectionResource()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Schema: %v", schemaResp.Diagnostics)
+	}
+
+	if diags := schemaResp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema implementation validation failed: %v", diags)
+	}
+
+	idAttr, ok := schemaResp.Schema.Attributes["id"].(resschema.StringAttribute)
+	if !ok || !idAttr.Computed {
+		t.Fatalf("'id' attribute must be a computed string")
+	}
+
+	providerAttr, ok := schemaResp.Schema.Attributes["provider_name"].(resschema.StringAttribute)
+	if !ok || !providerAttr.Required {
+		t.Fatalf("'provider_name' attribute must be a required string")
+	}
+}
+
+func TestLlmConnectionResourceCRUD(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	r, ok := NewLlmConnectionResource().(*llmConnectionResource)
+	if !ok {
+		t.Fatalf("factory did not return *llmConnectionResource")
+	}
+
+	clientFactory := mocks.NewMockClientFactory(ctrl)
+
+	var resourceSchema resschema.Schema
+	t.Run("Configure", func(t *testing.T) {
+		var configureResp resource.ConfigureResponse
+		r.Configure(ctx, resource.ConfigureRequest{ProviderData: clientFactory}, &configureResp)
+		if configureResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics from Configure: %v", configureResp.Diagnostics)
+		}
+
+		var schemaResp resource.SchemaResponse
+		r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+		if schemaResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics from Schema: %v", schemaResp.Diagnostics)
+		}
+		resourceSchema = schemaResp.Schema
+	})
+
+	projectPublicKey := "pk-test"
+	projectSecretKey := "sk-test"
+	providerName := "openai"
+	adapter := "openai"
+	secretKey := "llm-secret"
+
+	connID := "llm-conn-123"
+
+	var createResp resource.CreateResponse
+	t.Run("Create", func(t *testing.T) {
+		clientFactory.OrganizationClient.EXPECT().UpsertLlmConnection(ctx, &langfuse.UpsertLlmConnectionRequest{
+			Provider:  providerName,
+			Adapter:   adapter,
+			SecretKey: secretKey,
+		}).Return(&langfuse.LlmConnection{
+			ID:                connID,
+			Provider:          providerName,
+			Adapter:           adapter,
+			DisplaySecretKey:  "****",
+			CustomModels:      []string{},
+			WithDefaultModels: true,
+			ExtraHeaderKeys:   []string{},
+			CreatedAt:         "2026-01-01T00:00:00Z",
+			UpdatedAt:         "2026-01-01T00:00:00Z",
+		}, nil)
+
+		createConfig := tfsdk.Config{Raw: buildLlmConnectionObjectValue(map[string]tftypes.Value{
+			"id":                  tftypes.NewValue(tftypes.String, nil),
+			"project_public_key":  tftypes.NewValue(tftypes.String, projectPublicKey),
+			"project_secret_key":  tftypes.NewValue(tftypes.String, projectSecretKey),
+			"provider_name":       tftypes.NewValue(tftypes.String, providerName),
+			"adapter":             tftypes.NewValue(tftypes.String, adapter),
+			"secret_key":          tftypes.NewValue(tftypes.String, secretKey),
+			"base_url":            tftypes.NewValue(tftypes.String, nil),
+			"custom_models":       tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+			"with_default_models": tftypes.NewValue(tftypes.Bool, nil),
+			"extra_headers":       tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+			"config_json":         tftypes.NewValue(tftypes.String, nil),
+			"display_secret_key":  tftypes.NewValue(tftypes.String, nil),
+			"extra_header_keys":   tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+			"created_at":          tftypes.NewValue(tftypes.String, nil),
+			"updated_at":          tftypes.NewValue(tftypes.String, nil),
+		}), Schema: resourceSchema}
+		createResp.State.Schema = resourceSchema
+
+		r.Create(ctx, resource.CreateRequest{Config: createConfig}, &createResp)
+		if createResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics from Create: %v", createResp.Diagnostics)
+		}
+	})
+
+	var readResp resource.ReadResponse
+	t.Run("Read", func(t *testing.T) {
+		clientFactory.OrganizationClient.EXPECT().ListLlmConnections(ctx, 1, 100).Return(&langfuse.PaginatedLlmConnections{
+			Data: []langfuse.LlmConnection{{
+				ID:                connID,
+				Provider:          providerName,
+				Adapter:           adapter,
+				DisplaySecretKey:  "****",
+				CustomModels:      []string{"gpt-4o"},
+				WithDefaultModels: true,
+				ExtraHeaderKeys:   []string{"x-test"},
+				CreatedAt:         "2026-01-01T00:00:00Z",
+				UpdatedAt:         "2026-01-02T00:00:00Z",
+			}},
+			Meta: langfuse.MetaResponse{Page: 1, Limit: 100, TotalItems: 1, TotalPages: 1},
+		}, nil)
+
+		readResp.State.Schema = resourceSchema
+		r.Read(ctx, resource.ReadRequest{State: createResp.State}, &readResp)
+		if readResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics from Read: %v", readResp.Diagnostics)
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		var deleteResp resource.DeleteResponse
+		deleteResp.State.Schema = resourceSchema
+		r.Delete(ctx, resource.DeleteRequest{State: readResp.State}, &deleteResp)
+		if deleteResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics from Delete: %v", deleteResp.Diagnostics)
+		}
+	})
+}
+
+func buildLlmConnectionObjectValue(values map[string]tftypes.Value) tftypes.Value {
+	return tftypes.NewValue(
+		tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"id":                  tftypes.String,
+				"project_public_key":  tftypes.String,
+				"project_secret_key":  tftypes.String,
+				"provider_name":       tftypes.String,
+				"adapter":             tftypes.String,
+				"secret_key":          tftypes.String,
+				"base_url":            tftypes.String,
+				"custom_models":       tftypes.List{ElementType: tftypes.String},
+				"with_default_models": tftypes.Bool,
+				"extra_headers":       tftypes.Map{ElementType: tftypes.String},
+				"config_json":         tftypes.String,
+				"display_secret_key":  tftypes.String,
+				"extra_header_keys":   tftypes.List{ElementType: tftypes.String},
+				"created_at":          tftypes.String,
+				"updated_at":          tftypes.String,
+			},
+			OptionalAttributes: map[string]struct{}{
+				"id":                  {},
+				"base_url":            {},
+				"custom_models":       {},
+				"with_default_models": {},
+				"extra_headers":       {},
+				"config_json":         {},
+				"display_secret_key":  {},
+				"extra_header_keys":   {},
+				"created_at":          {},
+				"updated_at":          {},
+			},
+		},
+		values,
+	)
+}

--- a/internal/provider/organization_api_key_resource.go
+++ b/internal/provider/organization_api_key_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"strings"
 
 	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -109,7 +110,11 @@ func (r *organizationApiKeyResource) Read(ctx context.Context, req resource.Read
 
 	_, err := r.AdminClient.GetOrganizationApiKey(ctx, data.OrganizationID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.State.RemoveResource(ctx)
+		if strings.Contains(err.Error(), "cannot find API key") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading organization API key", err.Error())
 		return
 	}
 

--- a/internal/provider/organization_api_key_resource_unit_test.go
+++ b/internal/provider/organization_api_key_resource_unit_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -128,6 +129,91 @@ func TestOrganizationApiKeyResourceCRUD(t *testing.T) {
 			t.Fatalf("unexpected diagnostics from Delete: %v", deleteResp.Diagnostics)
 		}
 	})
+}
+
+func TestOrganizationApiKeyResource_Read_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	clientFactory := mocks.NewMockClientFactory(ctrl)
+	r := &organizationApiKeyResource{}
+	var configureResp resource.ConfigureResponse
+	r.Configure(ctx, resource.ConfigureRequest{ProviderData: clientFactory}, &configureResp)
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	state := tfsdk.State{
+		Schema: schemaResp.Schema,
+		Raw: buildOrgApiKeyObjectValue(map[string]tftypes.Value{
+			"id":              tftypes.NewValue(tftypes.String, "oak-123"),
+			"organization_id": tftypes.NewValue(tftypes.String, "org-123"),
+			"public_key":      tftypes.NewValue(tftypes.String, "pk-1234"),
+			"secret_key":      tftypes.NewValue(tftypes.String, "sk-1234"),
+		}),
+	}
+
+	clientFactory.AdminClient.EXPECT().
+		GetOrganizationApiKey(ctx, "org-123", "oak-123").
+		Return(nil, fmt.Errorf("cannot find API key with ID oak-123 in organization org-123"))
+
+	var resp resource.ReadResponse
+	resp.State.Schema = schemaResp.Schema
+	r.Read(ctx, resource.ReadRequest{State: state}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected no diagnostics, got: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatal("expected state to be removed (null) when key is not found")
+	}
+}
+
+func TestOrganizationApiKeyResource_Read_Error(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	clientFactory := mocks.NewMockClientFactory(ctrl)
+	r := &organizationApiKeyResource{}
+	var configureResp resource.ConfigureResponse
+	r.Configure(ctx, resource.ConfigureRequest{ProviderData: clientFactory}, &configureResp)
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	state := tfsdk.State{
+		Schema: schemaResp.Schema,
+		Raw: buildOrgApiKeyObjectValue(map[string]tftypes.Value{
+			"id":              tftypes.NewValue(tftypes.String, "oak-123"),
+			"organization_id": tftypes.NewValue(tftypes.String, "org-123"),
+			"public_key":      tftypes.NewValue(tftypes.String, "pk-1234"),
+			"secret_key":      tftypes.NewValue(tftypes.String, "sk-1234"),
+		}),
+	}
+
+	clientFactory.AdminClient.EXPECT().
+		GetOrganizationApiKey(ctx, "org-123", "oak-123").
+		Return(nil, fmt.Errorf("internal server error"))
+
+	var resp resource.ReadResponse
+	resp.State.Schema = schemaResp.Schema
+	r.Read(ctx, resource.ReadRequest{State: state}, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic for non-404 error, got none")
+	}
+	errs := resp.Diagnostics.Errors()
+	if errs[0].Summary() != "Error reading organization API key" {
+		t.Fatalf("unexpected error summary: %q", errs[0].Summary())
+	}
 }
 
 func buildOrgApiKeyObjectValue(values map[string]tftypes.Value) tftypes.Value {

--- a/internal/provider/organization_datasource.go
+++ b/internal/provider/organization_datasource.go
@@ -1,0 +1,149 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
+)
+
+var _ datasource.DataSource = &organizationDataSource{}
+var _ datasource.DataSourceWithValidateConfig = &organizationDataSource{}
+
+func NewOrganizationDataSource() datasource.DataSource {
+	return &organizationDataSource{}
+}
+
+type organizationDataSourceModel struct {
+	ID       types.String `tfsdk:"id"`
+	Name     types.String `tfsdk:"name"`
+	Metadata types.Map    `tfsdk:"metadata"`
+}
+
+type organizationDataSource struct {
+	AdminClient langfuse.AdminClient
+}
+
+func (d *organizationDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	d.AdminClient = req.ProviderData.(langfuse.ClientFactory).NewAdminClient()
+}
+
+func (d *organizationDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_organization"
+}
+
+func (d *organizationDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to look up a Langfuse organization by its ID or name.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The unique identifier of the organization. Exactly one of `id` or `name` must be specified.",
+			},
+			"name": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The display name of the organization. Exactly one of `id` or `name` must be specified.",
+			},
+			"metadata": schema.MapAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "Metadata for the organization as key-value pairs.",
+			},
+		},
+	}
+}
+
+func (d *organizationDataSource) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	var data organizationDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	idSet := !data.ID.IsNull() && !data.ID.IsUnknown()
+	nameSet := !data.Name.IsNull() && !data.Name.IsUnknown()
+
+	if !idSet && !nameSet {
+		resp.Diagnostics.AddError(
+			"Missing required argument",
+			"Exactly one of `id` or `name` must be specified.",
+		)
+	}
+
+	if idSet && nameSet {
+		resp.Diagnostics.AddError(
+			"Conflicting arguments",
+			"Exactly one of `id` or `name` must be specified, not both.",
+		)
+	}
+}
+
+func (d *organizationDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data organizationDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var org *langfuse.Organization
+	var err error
+
+	if !data.ID.IsNull() && !data.ID.IsUnknown() {
+		org, err = d.AdminClient.GetOrganization(ctx, data.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading organization by ID", err.Error())
+			return
+		}
+	} else {
+		orgs, listErr := d.AdminClient.ListOrganizations(ctx)
+		if listErr != nil {
+			resp.Diagnostics.AddError("Error listing organizations", listErr.Error())
+			return
+		}
+
+		targetName := data.Name.ValueString()
+		for _, o := range orgs {
+			if o.Name == targetName {
+				org = o
+				break
+			}
+		}
+
+		if org == nil {
+			resp.Diagnostics.AddError(
+				"Organization not found",
+				fmt.Sprintf("No organization found with name %q.", targetName),
+			)
+			return
+		}
+	}
+
+	var metadataMap types.Map
+	if len(org.Metadata) > 0 {
+		var diags diag.Diagnostics
+		metadataMap, diags = types.MapValueFrom(ctx, types.StringType, org.Metadata)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	} else {
+		metadataMap = types.MapNull(types.StringType)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &organizationDataSourceModel{
+		ID:       types.StringValue(org.ID),
+		Name:     types.StringValue(org.Name),
+		Metadata: metadataMap,
+	})...)
+}

--- a/internal/provider/organization_datasource_unit_test.go
+++ b/internal/provider/organization_datasource_unit_test.go
@@ -1,0 +1,442 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse/mocks"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestOrganizationDataSourceMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	d := NewOrganizationDataSource().(*organizationDataSource)
+
+	var resp datasource.MetadataResponse
+	d.Metadata(ctx, datasource.MetadataRequest{ProviderTypeName: "langfuse"}, &resp)
+
+	expected := "langfuse_organization"
+	if resp.TypeName != expected {
+		t.Fatalf("unexpected type name. got %q, want %q", resp.TypeName, expected)
+	}
+}
+
+func TestOrganizationDataSourceSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	d := NewOrganizationDataSource().(*organizationDataSource)
+
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Schema: %v", schemaResp.Diagnostics)
+	}
+
+	if diags := schemaResp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema implementation validation failed: %v", diags)
+	}
+
+	idAttrRaw, ok := schemaResp.Schema.Attributes["id"]
+	if !ok {
+		t.Fatalf("schema is missing 'id' attribute")
+	}
+
+	idAttr, ok := idAttrRaw.(dsschema.StringAttribute)
+	if !ok {
+		t.Fatalf("'id' attribute is not a string attribute as expected")
+	}
+
+	if !idAttr.Optional || !idAttr.Computed {
+		t.Fatalf("'id' attribute must be Optional=true and Computed=true")
+	}
+
+	nameAttrRaw, ok := schemaResp.Schema.Attributes["name"]
+	if !ok {
+		t.Fatalf("schema is missing 'name' attribute")
+	}
+
+	nameAttr, ok := nameAttrRaw.(dsschema.StringAttribute)
+	if !ok {
+		t.Fatalf("'name' attribute is not a string attribute as expected")
+	}
+
+	if !nameAttr.Optional || !nameAttr.Computed {
+		t.Fatalf("'name' attribute must be Optional=true and Computed=true")
+	}
+
+	metadataAttrRaw, ok := schemaResp.Schema.Attributes["metadata"]
+	if !ok {
+		t.Fatalf("schema is missing 'metadata' attribute")
+	}
+
+	metadataAttr, ok := metadataAttrRaw.(dsschema.MapAttribute)
+	if !ok {
+		t.Fatalf("'metadata' attribute is not a map attribute as expected")
+	}
+
+	if !metadataAttr.Computed {
+		t.Fatalf("'metadata' attribute must be Computed=true")
+	}
+}
+
+func TestOrganizationDataSourceValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	d := NewOrganizationDataSource().(*organizationDataSource)
+
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+	dataSourceSchema := schemaResp.Schema
+
+	t.Run("NeitherIdNorName", func(t *testing.T) {
+		config := tfsdk.Config{
+			Raw: buildDataSourceObjectValue(map[string]tftypes.Value{
+				"id":       tftypes.NewValue(tftypes.String, nil),
+				"name":     tftypes.NewValue(tftypes.String, nil),
+				"metadata": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var resp datasource.ValidateConfigResponse
+		d.ValidateConfig(ctx, datasource.ValidateConfigRequest{Config: config}, &resp)
+
+		if !resp.Diagnostics.HasError() {
+			t.Fatalf("expected error when neither id nor name is set")
+		}
+	})
+
+	t.Run("BothIdAndName", func(t *testing.T) {
+		config := tfsdk.Config{
+			Raw: buildDataSourceObjectValue(map[string]tftypes.Value{
+				"id":       tftypes.NewValue(tftypes.String, "org-123"),
+				"name":     tftypes.NewValue(tftypes.String, "Acme Inc"),
+				"metadata": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var resp datasource.ValidateConfigResponse
+		d.ValidateConfig(ctx, datasource.ValidateConfigRequest{Config: config}, &resp)
+
+		if !resp.Diagnostics.HasError() {
+			t.Fatalf("expected error when both id and name are set")
+		}
+	})
+
+	t.Run("OnlyId", func(t *testing.T) {
+		config := tfsdk.Config{
+			Raw: buildDataSourceObjectValue(map[string]tftypes.Value{
+				"id":       tftypes.NewValue(tftypes.String, "org-123"),
+				"name":     tftypes.NewValue(tftypes.String, nil),
+				"metadata": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var resp datasource.ValidateConfigResponse
+		d.ValidateConfig(ctx, datasource.ValidateConfigRequest{Config: config}, &resp)
+
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected error when only id is set: %v", resp.Diagnostics)
+		}
+	})
+
+	t.Run("OnlyName", func(t *testing.T) {
+		config := tfsdk.Config{
+			Raw: buildDataSourceObjectValue(map[string]tftypes.Value{
+				"id":       tftypes.NewValue(tftypes.String, nil),
+				"name":     tftypes.NewValue(tftypes.String, "Acme Inc"),
+				"metadata": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var resp datasource.ValidateConfigResponse
+		d.ValidateConfig(ctx, datasource.ValidateConfigRequest{Config: config}, &resp)
+
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected error when only name is set: %v", resp.Diagnostics)
+		}
+	})
+}
+
+func TestOrganizationDataSourceRead(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	d := NewOrganizationDataSource().(*organizationDataSource)
+
+	clientFactory := mocks.NewMockClientFactory(ctrl)
+
+	var dataSourceSchema dsschema.Schema
+	t.Run("Configure", func(t *testing.T) {
+		var configureResp datasource.ConfigureResponse
+		d.Configure(ctx, datasource.ConfigureRequest{ProviderData: clientFactory}, &configureResp)
+
+		if configureResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics from Configure: %v", configureResp.Diagnostics)
+		}
+
+		if d.AdminClient == nil {
+			t.Fatalf("Configure did not populate AdminClient on the data source")
+		}
+
+		var schemaResp datasource.SchemaResponse
+		d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+		if schemaResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics from Schema: %v", schemaResp.Diagnostics)
+		}
+		dataSourceSchema = schemaResp.Schema
+	})
+
+	t.Run("ReadByID", func(t *testing.T) {
+		orgID := "org-123"
+		orgName := "Acme Inc"
+		orgMetadata := map[string]string{"environment": "test", "team": "platform"}
+
+		clientFactory.AdminClient.EXPECT().
+			GetOrganization(ctx, orgID).
+			Return(&langfuse.Organization{
+				ID:       orgID,
+				Name:     orgName,
+				Metadata: orgMetadata,
+			}, nil)
+
+		readConfig := tfsdk.Config{
+			Raw: buildDataSourceObjectValue(map[string]tftypes.Value{
+				"id":       tftypes.NewValue(tftypes.String, orgID),
+				"name":     tftypes.NewValue(tftypes.String, nil),
+				"metadata": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var readResp datasource.ReadResponse
+		readResp.State.Schema = dataSourceSchema
+
+		d.Read(ctx, datasource.ReadRequest{Config: readConfig}, &readResp)
+
+		if readResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics from Read: %v", readResp.Diagnostics)
+		}
+
+		var model organizationDataSourceModel
+		diags := readResp.State.Get(ctx, &model)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics getting model from state: %v", diags)
+		}
+
+		if model.ID.ValueString() != orgID {
+			t.Fatalf("unexpected ID. got %q, want %q", model.ID.ValueString(), orgID)
+		}
+
+		if model.Name.ValueString() != orgName {
+			t.Fatalf("unexpected name. got %q, want %q", model.Name.ValueString(), orgName)
+		}
+
+		if model.Metadata.IsNull() {
+			t.Fatalf("metadata should not be null")
+		}
+
+		var actualMetadata map[string]string
+		diags = model.Metadata.ElementsAs(ctx, &actualMetadata, false)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics extracting metadata: %v", diags)
+		}
+
+		for key, expectedValue := range orgMetadata {
+			if actualValue, exists := actualMetadata[key]; !exists || actualValue != expectedValue {
+				t.Fatalf("unexpected metadata for key %q. got %q, want %q", key, actualValue, expectedValue)
+			}
+		}
+	})
+
+	t.Run("ReadByName", func(t *testing.T) {
+		orgID := "org-789"
+		orgName := "By Name Org"
+		orgMetadata := map[string]string{"tier": "enterprise"}
+
+		clientFactory.AdminClient.EXPECT().
+			ListOrganizations(ctx).
+			Return([]*langfuse.Organization{
+				{ID: "org-other", Name: "Other Org", Metadata: nil},
+				{ID: orgID, Name: orgName, Metadata: orgMetadata},
+			}, nil)
+
+		readConfig := tfsdk.Config{
+			Raw: buildDataSourceObjectValue(map[string]tftypes.Value{
+				"id":       tftypes.NewValue(tftypes.String, nil),
+				"name":     tftypes.NewValue(tftypes.String, orgName),
+				"metadata": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var readResp datasource.ReadResponse
+		readResp.State.Schema = dataSourceSchema
+
+		d.Read(ctx, datasource.ReadRequest{Config: readConfig}, &readResp)
+
+		if readResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics from Read: %v", readResp.Diagnostics)
+		}
+
+		var model organizationDataSourceModel
+		diags := readResp.State.Get(ctx, &model)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics getting model from state: %v", diags)
+		}
+
+		if model.ID.ValueString() != orgID {
+			t.Fatalf("unexpected ID. got %q, want %q", model.ID.ValueString(), orgID)
+		}
+
+		if model.Name.ValueString() != orgName {
+			t.Fatalf("unexpected name. got %q, want %q", model.Name.ValueString(), orgName)
+		}
+	})
+
+	t.Run("ReadByName_NotFound", func(t *testing.T) {
+		clientFactory.AdminClient.EXPECT().
+			ListOrganizations(ctx).
+			Return([]*langfuse.Organization{
+				{ID: "org-1", Name: "Existing Org", Metadata: nil},
+			}, nil)
+
+		readConfig := tfsdk.Config{
+			Raw: buildDataSourceObjectValue(map[string]tftypes.Value{
+				"id":       tftypes.NewValue(tftypes.String, nil),
+				"name":     tftypes.NewValue(tftypes.String, "Nonexistent Org"),
+				"metadata": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var readResp datasource.ReadResponse
+		readResp.State.Schema = dataSourceSchema
+
+		d.Read(ctx, datasource.ReadRequest{Config: readConfig}, &readResp)
+
+		if !readResp.Diagnostics.HasError() {
+			t.Fatalf("expected error when organization name is not found")
+		}
+
+		found := false
+		for _, diag := range readResp.Diagnostics.Errors() {
+			if diag.Summary() == "Organization not found" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected 'Organization not found' error, got: %v", readResp.Diagnostics)
+		}
+	})
+
+	t.Run("ReadByID_EmptyMetadata", func(t *testing.T) {
+		orgID := "org-456"
+		orgName := "Empty Org"
+
+		clientFactory.AdminClient.EXPECT().
+			GetOrganization(ctx, orgID).
+			Return(&langfuse.Organization{
+				ID:       orgID,
+				Name:     orgName,
+				Metadata: nil,
+			}, nil)
+
+		readConfig := tfsdk.Config{
+			Raw: buildDataSourceObjectValue(map[string]tftypes.Value{
+				"id":       tftypes.NewValue(tftypes.String, orgID),
+				"name":     tftypes.NewValue(tftypes.String, nil),
+				"metadata": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var readResp datasource.ReadResponse
+		readResp.State.Schema = dataSourceSchema
+
+		d.Read(ctx, datasource.ReadRequest{Config: readConfig}, &readResp)
+
+		if readResp.Diagnostics.HasError() {
+			t.Fatalf("unexpected diagnostics from Read: %v", readResp.Diagnostics)
+		}
+
+		var model organizationDataSourceModel
+		diags := readResp.State.Get(ctx, &model)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics getting model from state: %v", diags)
+		}
+
+		if model.ID.ValueString() != orgID {
+			t.Fatalf("unexpected ID. got %q, want %q", model.ID.ValueString(), orgID)
+		}
+
+		if model.Name.ValueString() != orgName {
+			t.Fatalf("unexpected name. got %q, want %q", model.Name.ValueString(), orgName)
+		}
+
+		if !model.Metadata.IsNull() {
+			t.Fatalf("metadata should be null when empty, got %v", model.Metadata)
+		}
+	})
+
+	t.Run("ReadByID_Error", func(t *testing.T) {
+		orgID := "org-bad"
+
+		clientFactory.AdminClient.EXPECT().
+			GetOrganization(ctx, orgID).
+			Return(nil, fmt.Errorf("not found"))
+
+		readConfig := tfsdk.Config{
+			Raw: buildDataSourceObjectValue(map[string]tftypes.Value{
+				"id":       tftypes.NewValue(tftypes.String, orgID),
+				"name":     tftypes.NewValue(tftypes.String, nil),
+				"metadata": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var readResp datasource.ReadResponse
+		readResp.State.Schema = dataSourceSchema
+
+		d.Read(ctx, datasource.ReadRequest{Config: readConfig}, &readResp)
+
+		if !readResp.Diagnostics.HasError() {
+			t.Fatalf("expected error when GetOrganization fails")
+		}
+	})
+}
+
+func buildDataSourceObjectValue(values map[string]tftypes.Value) tftypes.Value {
+	return tftypes.NewValue(
+		tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"id":       tftypes.String,
+				"name":     tftypes.String,
+				"metadata": tftypes.Map{ElementType: tftypes.String},
+			},
+		},
+		values,
+	)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -68,7 +68,9 @@ func (p *langfuseProvider) Configure(ctx context.Context, req provider.Configure
 }
 
 func (p *langfuseProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{}
+	return []func() datasource.DataSource{
+		NewOrganizationDataSource,
+	}
 }
 
 func (p *langfuseProvider) Resources(ctx context.Context) []func() resource.Resource {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -78,6 +78,7 @@ func (p *langfuseProvider) Resources(ctx context.Context) []func() resource.Reso
 		NewOrganizationMembershipResource,
 		NewProjectResource,
 		NewProjectApiKeyResource,
+		NewLlmConnectionResource,
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -70,6 +70,7 @@ func (p *langfuseProvider) Configure(ctx context.Context, req provider.Configure
 func (p *langfuseProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewOrganizationDataSource,
+		NewUserDataSource,
 	}
 }
 

--- a/internal/provider/user_datasource.go
+++ b/internal/provider/user_datasource.go
@@ -1,0 +1,163 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
+)
+
+var _ datasource.DataSource = &userDataSource{}
+var _ datasource.DataSourceWithValidateConfig = &userDataSource{}
+
+func NewUserDataSource() datasource.DataSource {
+	return &userDataSource{}
+}
+
+type userDataSourceModel struct {
+	ID                     types.String `tfsdk:"id"`
+	Email                  types.String `tfsdk:"email"`
+	UserName               types.String `tfsdk:"user_name"`
+	Active                 types.Bool   `tfsdk:"active"`
+	OrganizationPublicKey  types.String `tfsdk:"organization_public_key"`
+	OrganizationPrivateKey types.String `tfsdk:"organization_private_key"`
+}
+
+type userDataSource struct {
+	ClientFactory langfuse.ClientFactory
+}
+
+func (d *userDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	clientFactory, ok := req.ProviderData.(langfuse.ClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected DataSource Configure Type",
+			fmt.Sprintf("Expected langfuse.ClientFactory, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.ClientFactory = clientFactory
+}
+
+func (d *userDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_user"
+}
+
+func (d *userDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Use this data source to look up a Langfuse user by ID or email.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The unique identifier of the user (SCIM ID). Exactly one of `id` or `email` must be specified.",
+			},
+			"email": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "The email address (userName) of the user. Exactly one of `id` or `email` must be specified.",
+			},
+			"user_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "The SCIM userName of the user (same as email).",
+			},
+			"active": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Whether the user account is active.",
+			},
+			"organization_public_key": schema.StringAttribute{
+				Required:    true,
+				Sensitive:   true,
+				Description: "Organization public key to authenticate the call.",
+			},
+			"organization_private_key": schema.StringAttribute{
+				Required:    true,
+				Sensitive:   true,
+				Description: "Organization private key to authenticate the call.",
+			},
+		},
+	}
+}
+
+func (d *userDataSource) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	var data userDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	idSet := !data.ID.IsNull() && !data.ID.IsUnknown()
+	emailSet := !data.Email.IsNull() && !data.Email.IsUnknown()
+
+	if !idSet && !emailSet {
+		resp.Diagnostics.AddError(
+			"Missing required argument",
+			"Exactly one of `id` or `email` must be specified.",
+		)
+	}
+
+	if idSet && emailSet {
+		resp.Diagnostics.AddError(
+			"Conflicting arguments",
+			"Exactly one of `id` or `email` must be specified, not both.",
+		)
+	}
+}
+
+func (d *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data userDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	organizationClient := d.ClientFactory.NewOrganizationClient(
+		data.OrganizationPublicKey.ValueString(),
+		data.OrganizationPrivateKey.ValueString(),
+	)
+
+	var user *langfuse.SCIMUserResponse
+	var err error
+
+	if !data.ID.IsNull() && !data.ID.IsUnknown() {
+		user, err = organizationClient.GetSCIMUser(ctx, data.ID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Error reading user by ID", err.Error())
+			return
+		}
+	} else {
+		user, err = organizationClient.FindSCIMUserByEmail(ctx, data.Email.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Error finding user by email", err.Error())
+			return
+		}
+	}
+
+	email := ""
+	for _, e := range user.Emails {
+		if e.Primary {
+			email = e.Value
+			break
+		}
+	}
+	if email == "" && len(user.Emails) > 0 {
+		email = user.Emails[0].Value
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &userDataSourceModel{
+		ID:                     types.StringValue(user.ID),
+		Email:                  types.StringValue(email),
+		UserName:               types.StringValue(user.UserName),
+		Active:                 types.BoolValue(user.Active),
+		OrganizationPublicKey:  data.OrganizationPublicKey,
+		OrganizationPrivateKey: data.OrganizationPrivateKey,
+	})...)
+}

--- a/internal/provider/user_datasource_unit_test.go
+++ b/internal/provider/user_datasource_unit_test.go
@@ -1,0 +1,454 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse"
+	"github.com/langfuse/terraform-provider-langfuse/internal/langfuse/mocks"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func buildUserDataSourceObjectValue(values map[string]tftypes.Value) tftypes.Value {
+	return tftypes.NewValue(
+		tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"id":                      tftypes.String,
+				"email":                   tftypes.String,
+				"user_name":               tftypes.String,
+				"active":                  tftypes.Bool,
+				"organization_public_key":  tftypes.String,
+				"organization_private_key": tftypes.String,
+			},
+		},
+		values,
+	)
+}
+
+func TestUserDataSourceMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	d := NewUserDataSource().(*userDataSource)
+
+	var resp datasource.MetadataResponse
+	d.Metadata(ctx, datasource.MetadataRequest{ProviderTypeName: "langfuse"}, &resp)
+
+	expected := "langfuse_user"
+	if resp.TypeName != expected {
+		t.Fatalf("unexpected type name. got %q, want %q", resp.TypeName, expected)
+	}
+}
+
+func TestUserDataSourceSchema(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	d := NewUserDataSource().(*userDataSource)
+
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Schema: %v", schemaResp.Diagnostics)
+	}
+
+	if diags := schemaResp.Schema.ValidateImplementation(ctx); diags.HasError() {
+		t.Fatalf("schema implementation validation failed: %v", diags)
+	}
+
+	idAttrRaw, ok := schemaResp.Schema.Attributes["id"]
+	if !ok {
+		t.Fatalf("schema is missing 'id' attribute")
+	}
+	idAttr, ok := idAttrRaw.(dsschema.StringAttribute)
+	if !ok {
+		t.Fatalf("'id' attribute is not a StringAttribute")
+	}
+	if !idAttr.Optional || !idAttr.Computed {
+		t.Fatalf("'id' attribute must be Optional=true and Computed=true")
+	}
+
+	emailAttrRaw, ok := schemaResp.Schema.Attributes["email"]
+	if !ok {
+		t.Fatalf("schema is missing 'email' attribute")
+	}
+	emailAttr, ok := emailAttrRaw.(dsschema.StringAttribute)
+	if !ok {
+		t.Fatalf("'email' attribute is not a StringAttribute")
+	}
+	if !emailAttr.Optional || !emailAttr.Computed {
+		t.Fatalf("'email' attribute must be Optional=true and Computed=true")
+	}
+
+	userNameAttrRaw, ok := schemaResp.Schema.Attributes["user_name"]
+	if !ok {
+		t.Fatalf("schema is missing 'user_name' attribute")
+	}
+	userNameAttr, ok := userNameAttrRaw.(dsschema.StringAttribute)
+	if !ok {
+		t.Fatalf("'user_name' attribute is not a StringAttribute")
+	}
+	if !userNameAttr.Computed {
+		t.Fatalf("'user_name' attribute must be Computed=true")
+	}
+
+	activeAttrRaw, ok := schemaResp.Schema.Attributes["active"]
+	if !ok {
+		t.Fatalf("schema is missing 'active' attribute")
+	}
+	activeAttr, ok := activeAttrRaw.(dsschema.BoolAttribute)
+	if !ok {
+		t.Fatalf("'active' attribute is not a BoolAttribute")
+	}
+	if !activeAttr.Computed {
+		t.Fatalf("'active' attribute must be Computed=true")
+	}
+
+	pubKeyAttrRaw, ok := schemaResp.Schema.Attributes["organization_public_key"]
+	if !ok {
+		t.Fatalf("schema is missing 'organization_public_key' attribute")
+	}
+	pubKeyAttr, ok := pubKeyAttrRaw.(dsschema.StringAttribute)
+	if !ok {
+		t.Fatalf("'organization_public_key' attribute is not a StringAttribute")
+	}
+	if !pubKeyAttr.Required || !pubKeyAttr.Sensitive {
+		t.Fatalf("'organization_public_key' attribute must be Required=true and Sensitive=true")
+	}
+
+	privKeyAttrRaw, ok := schemaResp.Schema.Attributes["organization_private_key"]
+	if !ok {
+		t.Fatalf("schema is missing 'organization_private_key' attribute")
+	}
+	privKeyAttr, ok := privKeyAttrRaw.(dsschema.StringAttribute)
+	if !ok {
+		t.Fatalf("'organization_private_key' attribute is not a StringAttribute")
+	}
+	if !privKeyAttr.Required || !privKeyAttr.Sensitive {
+		t.Fatalf("'organization_private_key' attribute must be Required=true and Sensitive=true")
+	}
+}
+
+func TestUserDataSourceValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	d := NewUserDataSource().(*userDataSource)
+
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+	dataSourceSchema := schemaResp.Schema
+
+	pubKey := tftypes.NewValue(tftypes.String, "pk-test")
+	privKey := tftypes.NewValue(tftypes.String, "sk-test")
+
+	t.Run("NeitherIdNorEmail", func(t *testing.T) {
+		config := tfsdk.Config{
+			Raw: buildUserDataSourceObjectValue(map[string]tftypes.Value{
+				"id":                      tftypes.NewValue(tftypes.String, nil),
+				"email":                   tftypes.NewValue(tftypes.String, nil),
+				"user_name":               tftypes.NewValue(tftypes.String, nil),
+				"active":                  tftypes.NewValue(tftypes.Bool, nil),
+				"organization_public_key":  pubKey,
+				"organization_private_key": privKey,
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var resp datasource.ValidateConfigResponse
+		d.ValidateConfig(ctx, datasource.ValidateConfigRequest{Config: config}, &resp)
+
+		if !resp.Diagnostics.HasError() {
+			t.Fatalf("expected error when neither id nor email is set")
+		}
+	})
+
+	t.Run("BothIdAndEmail", func(t *testing.T) {
+		config := tfsdk.Config{
+			Raw: buildUserDataSourceObjectValue(map[string]tftypes.Value{
+				"id":                      tftypes.NewValue(tftypes.String, "user-123"),
+				"email":                   tftypes.NewValue(tftypes.String, "user@example.com"),
+				"user_name":               tftypes.NewValue(tftypes.String, nil),
+				"active":                  tftypes.NewValue(tftypes.Bool, nil),
+				"organization_public_key":  pubKey,
+				"organization_private_key": privKey,
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var resp datasource.ValidateConfigResponse
+		d.ValidateConfig(ctx, datasource.ValidateConfigRequest{Config: config}, &resp)
+
+		if !resp.Diagnostics.HasError() {
+			t.Fatalf("expected error when both id and email are set")
+		}
+	})
+
+	t.Run("OnlyId", func(t *testing.T) {
+		config := tfsdk.Config{
+			Raw: buildUserDataSourceObjectValue(map[string]tftypes.Value{
+				"id":                      tftypes.NewValue(tftypes.String, "user-123"),
+				"email":                   tftypes.NewValue(tftypes.String, nil),
+				"user_name":               tftypes.NewValue(tftypes.String, nil),
+				"active":                  tftypes.NewValue(tftypes.Bool, nil),
+				"organization_public_key":  pubKey,
+				"organization_private_key": privKey,
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var resp datasource.ValidateConfigResponse
+		d.ValidateConfig(ctx, datasource.ValidateConfigRequest{Config: config}, &resp)
+
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected error when only id is set: %v", resp.Diagnostics)
+		}
+	})
+
+	t.Run("OnlyEmail", func(t *testing.T) {
+		config := tfsdk.Config{
+			Raw: buildUserDataSourceObjectValue(map[string]tftypes.Value{
+				"id":                      tftypes.NewValue(tftypes.String, nil),
+				"email":                   tftypes.NewValue(tftypes.String, "user@example.com"),
+				"user_name":               tftypes.NewValue(tftypes.String, nil),
+				"active":                  tftypes.NewValue(tftypes.Bool, nil),
+				"organization_public_key":  pubKey,
+				"organization_private_key": privKey,
+			}),
+			Schema: dataSourceSchema,
+		}
+
+		var resp datasource.ValidateConfigResponse
+		d.ValidateConfig(ctx, datasource.ValidateConfigRequest{Config: config}, &resp)
+
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unexpected error when only email is set: %v", resp.Diagnostics)
+		}
+	})
+}
+
+func TestUserDataSourceRead_ByID(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	d := NewUserDataSource().(*userDataSource)
+
+	clientFactory := mocks.NewMockClientFactory(ctrl)
+
+	var configureResp datasource.ConfigureResponse
+	d.Configure(ctx, datasource.ConfigureRequest{ProviderData: clientFactory}, &configureResp)
+	if configureResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Configure: %v", configureResp.Diagnostics)
+	}
+
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+	dataSourceSchema := schemaResp.Schema
+
+	userID := "user-abc"
+	userName := "user@example.com"
+
+	clientFactory.OrganizationClient.EXPECT().
+		GetSCIMUser(ctx, userID).
+		Return(&langfuse.SCIMUserResponse{
+			ID:       userID,
+			UserName: userName,
+			Emails: []struct {
+				Value   string `json:"value"`
+				Primary bool   `json:"primary"`
+			}{
+				{Value: userName, Primary: true},
+			},
+			Active: true,
+		}, nil)
+
+	readConfig := tfsdk.Config{
+		Raw: buildUserDataSourceObjectValue(map[string]tftypes.Value{
+			"id":                      tftypes.NewValue(tftypes.String, userID),
+			"email":                   tftypes.NewValue(tftypes.String, nil),
+			"user_name":               tftypes.NewValue(tftypes.String, nil),
+			"active":                  tftypes.NewValue(tftypes.Bool, nil),
+			"organization_public_key":  tftypes.NewValue(tftypes.String, "pk-test"),
+			"organization_private_key": tftypes.NewValue(tftypes.String, "sk-test"),
+		}),
+		Schema: dataSourceSchema,
+	}
+
+	var readResp datasource.ReadResponse
+	readResp.State.Schema = dataSourceSchema
+
+	d.Read(ctx, datasource.ReadRequest{Config: readConfig}, &readResp)
+
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Read: %v", readResp.Diagnostics)
+	}
+
+	var model userDataSourceModel
+	diags := readResp.State.Get(ctx, &model)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics getting model from state: %v", diags)
+	}
+
+	if model.ID.ValueString() != userID {
+		t.Fatalf("unexpected ID. got %q, want %q", model.ID.ValueString(), userID)
+	}
+	if model.Email.ValueString() != userName {
+		t.Fatalf("unexpected email. got %q, want %q", model.Email.ValueString(), userName)
+	}
+	if model.UserName.ValueString() != userName {
+		t.Fatalf("unexpected user_name. got %q, want %q", model.UserName.ValueString(), userName)
+	}
+	if !model.Active.ValueBool() {
+		t.Fatalf("expected active=true")
+	}
+}
+
+func TestUserDataSourceRead_ByEmail(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	d := NewUserDataSource().(*userDataSource)
+
+	clientFactory := mocks.NewMockClientFactory(ctrl)
+
+	var configureResp datasource.ConfigureResponse
+	d.Configure(ctx, datasource.ConfigureRequest{ProviderData: clientFactory}, &configureResp)
+	if configureResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Configure: %v", configureResp.Diagnostics)
+	}
+
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+	dataSourceSchema := schemaResp.Schema
+
+	userID := "user-xyz"
+	userEmail := "alice@example.com"
+
+	clientFactory.OrganizationClient.EXPECT().
+		FindSCIMUserByEmail(ctx, userEmail).
+		Return(&langfuse.SCIMUserResponse{
+			ID:       userID,
+			UserName: userEmail,
+			Emails: []struct {
+				Value   string `json:"value"`
+				Primary bool   `json:"primary"`
+			}{
+				{Value: userEmail, Primary: true},
+			},
+			Active: false,
+		}, nil)
+
+	readConfig := tfsdk.Config{
+		Raw: buildUserDataSourceObjectValue(map[string]tftypes.Value{
+			"id":                      tftypes.NewValue(tftypes.String, nil),
+			"email":                   tftypes.NewValue(tftypes.String, userEmail),
+			"user_name":               tftypes.NewValue(tftypes.String, nil),
+			"active":                  tftypes.NewValue(tftypes.Bool, nil),
+			"organization_public_key":  tftypes.NewValue(tftypes.String, "pk-test"),
+			"organization_private_key": tftypes.NewValue(tftypes.String, "sk-test"),
+		}),
+		Schema: dataSourceSchema,
+	}
+
+	var readResp datasource.ReadResponse
+	readResp.State.Schema = dataSourceSchema
+
+	d.Read(ctx, datasource.ReadRequest{Config: readConfig}, &readResp)
+
+	if readResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Read: %v", readResp.Diagnostics)
+	}
+
+	var model userDataSourceModel
+	diags := readResp.State.Get(ctx, &model)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics getting model from state: %v", diags)
+	}
+
+	if model.ID.ValueString() != userID {
+		t.Fatalf("unexpected ID. got %q, want %q", model.ID.ValueString(), userID)
+	}
+	if model.Email.ValueString() != userEmail {
+		t.Fatalf("unexpected email. got %q, want %q", model.Email.ValueString(), userEmail)
+	}
+	if model.UserName.ValueString() != userEmail {
+		t.Fatalf("unexpected user_name. got %q, want %q", model.UserName.ValueString(), userEmail)
+	}
+	if model.Active.ValueBool() {
+		t.Fatalf("expected active=false")
+	}
+}
+
+func TestUserDataSourceRead_Error(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	d := NewUserDataSource().(*userDataSource)
+
+	clientFactory := mocks.NewMockClientFactory(ctrl)
+
+	var configureResp datasource.ConfigureResponse
+	d.Configure(ctx, datasource.ConfigureRequest{ProviderData: clientFactory}, &configureResp)
+	if configureResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Configure: %v", configureResp.Diagnostics)
+	}
+
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+	dataSourceSchema := schemaResp.Schema
+
+	userID := "user-bad"
+
+	clientFactory.OrganizationClient.EXPECT().
+		GetSCIMUser(ctx, userID).
+		Return(nil, fmt.Errorf("not found"))
+
+	readConfig := tfsdk.Config{
+		Raw: buildUserDataSourceObjectValue(map[string]tftypes.Value{
+			"id":                      tftypes.NewValue(tftypes.String, userID),
+			"email":                   tftypes.NewValue(tftypes.String, nil),
+			"user_name":               tftypes.NewValue(tftypes.String, nil),
+			"active":                  tftypes.NewValue(tftypes.Bool, nil),
+			"organization_public_key":  tftypes.NewValue(tftypes.String, "pk-test"),
+			"organization_private_key": tftypes.NewValue(tftypes.String, "sk-test"),
+		}),
+		Schema: dataSourceSchema,
+	}
+
+	var readResp datasource.ReadResponse
+	readResp.State.Schema = dataSourceSchema
+
+	d.Read(ctx, datasource.ReadRequest{Config: readConfig}, &readResp)
+
+	if !readResp.Diagnostics.HasError() {
+		t.Fatalf("expected error when GetSCIMUser fails")
+	}
+
+	found := false
+	for _, diag := range readResp.Diagnostics.Errors() {
+		if diag.Summary() == "Error reading user by ID" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'Error reading user by ID' diagnostic, got: %v", readResp.Diagnostics)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `langfuse_user` data source to look up a Langfuse user by ID or email address
- Extends OrganizationClient with `GetSCIMUser` and `FindSCIMUserByEmail` using the SCIM API
- Full unit test coverage

## Usage
```hcl
data "langfuse_user" "example" {
  email                   = "user@example.com"
  organization_public_key  = langfuse_organization_api_key.example.public_key
  organization_private_key = langfuse_organization_api_key.example.secret_key
}
```

🤖 Generated with Claude Code