### PR TITLE
feat: add tls_server_name provider option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ provider "langfuse" {
 }
 ```
 
+#### Reaching an instance through a tunnel
+
+When a self-hosted instance is only reachable through an SSH tunnel, a
+`kubectl port-forward`, or an AWS SSM session, `host` points at a local port
+that cannot match the certificate the instance serves. Set `tls_server_name` to
+the hostname the certificate is issued for; it is used to verify the
+certificate and sent as the SNI value, while the connection still goes to the
+tunnel. Certificate verification stays enabled.
+
+```hcl
+provider "langfuse" {
+  host            = "https://localhost:8080"
+  tls_server_name = "langfuse.internal.example.com"
+  admin_api_key   = var.admin_api_key
+}
+```
+
 ### Environment Variables
 
 - `LANGFUSE_ADMIN_KEY` - Admin API key (alternative to `admin_api_key`)

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,3 +124,4 @@ output "project_api_public_key" {
 
 - `admin_api_key` (String, Sensitive) Admin API key. Only needed when managing organizations. Can also come from LANGFUSE_ADMIN_KEY.
 - `host` (String) Base URI of the Langfuse instance (defaults to https://app.langfuse.com).
+- `tls_server_name` (String) Hostname to verify the TLS certificate against, also sent as the SNI value. Set this when the instance is reached through a port forward or tunnel, where the host above (typically localhost) cannot match the certificate. Certificate verification remains enabled.

--- a/internal/langfuse/admin_client.go
+++ b/internal/langfuse/admin_client.go
@@ -63,11 +63,11 @@ type adminClientImpl struct {
 	httpClient *http.Client
 }
 
-func NewAdminClient(host, apiKey string) AdminClient {
+func NewAdminClient(host, apiKey string, httpClient *http.Client) AdminClient {
 	return &adminClientImpl{
 		host:       host,
 		apiKey:     apiKey,
-		httpClient: &http.Client{},
+		httpClient: httpClientOrDefault(httpClient),
 	}
 }
 

--- a/internal/langfuse/client_factory.go
+++ b/internal/langfuse/client_factory.go
@@ -1,8 +1,11 @@
 package langfuse
 
+import "net/http"
+
 type clientFactoryImpl struct {
 	host        string
 	adminApiKey string
+	httpClient  *http.Client
 }
 
 type ClientFactory interface {
@@ -11,21 +14,22 @@ type ClientFactory interface {
 	NewLlmConnectionsClient(publicKey, privateKey string) LlmConnectionsClient
 }
 
-func NewClientFactory(host, adminApiKey string) ClientFactory {
+func NewClientFactory(host, adminApiKey, tlsServerName string) ClientFactory {
 	return &clientFactoryImpl{
 		host:        host,
 		adminApiKey: adminApiKey,
+		httpClient:  newHTTPClient(tlsServerName),
 	}
 }
 
 func (cf *clientFactoryImpl) NewAdminClient() AdminClient {
-	return NewAdminClient(cf.host, cf.adminApiKey)
+	return NewAdminClient(cf.host, cf.adminApiKey, cf.httpClient)
 }
 
 func (cf *clientFactoryImpl) NewOrganizationClient(publicKey, privateKey string) OrganizationClient {
-	return NewOrganizationClient(cf.host, publicKey, privateKey)
+	return NewOrganizationClient(cf.host, publicKey, privateKey, cf.httpClient)
 }
 
 func (cf *clientFactoryImpl) NewLlmConnectionsClient(publicKey, privateKey string) LlmConnectionsClient {
-	return NewLlmConnectionsClient(cf.host, publicKey, privateKey)
+	return NewLlmConnectionsClient(cf.host, publicKey, privateKey, cf.httpClient)
 }

--- a/internal/langfuse/http_client.go
+++ b/internal/langfuse/http_client.go
@@ -1,0 +1,35 @@
+package langfuse
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+// newHTTPClient builds the HTTP client shared by the API clients.
+//
+// When tlsServerName is set, the certificate is verified against that name
+// instead of the host in the request URL, and that name is sent as the SNI
+// value. This is what allows an instance to be reached through a port forward
+// or tunnel, where the URL host is something like localhost:8080 and can never
+// match the certificate. Verification itself stays enabled.
+func newHTTPClient(tlsServerName string) *http.Client {
+	if tlsServerName == "" {
+		return &http.Client{}
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		ServerName: tlsServerName,
+		MinVersion: tls.VersionTLS12,
+	}
+
+	return &http.Client{Transport: transport}
+}
+
+func httpClientOrDefault(httpClient *http.Client) *http.Client {
+	if httpClient == nil {
+		return &http.Client{}
+	}
+
+	return httpClient
+}

--- a/internal/langfuse/http_client_test.go
+++ b/internal/langfuse/http_client_test.go
@@ -1,0 +1,83 @@
+package langfuse
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The httptest certificate covers the DNS name example.com as well as the
+// loopback addresses, so a request to the server's 127.0.0.1 URL would pass on
+// the IP alone. Overriding the verified name to something the certificate does
+// not cover is what proves the override is the name being checked.
+func newTestTLSServer(t *testing.T) (*httptest.Server, *x509.CertPool) {
+	t.Helper()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(server.Certificate())
+
+	return server, roots
+}
+
+func trustRoots(t *testing.T, client *http.Client, roots *x509.CertPool) {
+	t.Helper()
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected an *http.Transport, got %T", client.Transport)
+	}
+	transport.TLSClientConfig.RootCAs = roots
+}
+
+func TestNewHTTPClientWithoutServerNameKeepsDefaults(t *testing.T) {
+	if transport := newHTTPClient("").Transport; transport != nil {
+		t.Fatalf("expected the default transport, got %T", transport)
+	}
+}
+
+func TestNewHTTPClientVerifiesAgainstServerName(t *testing.T) {
+	server, roots := newTestTLSServer(t)
+
+	client := newHTTPClient("example.com")
+	trustRoots(t, client, roots)
+
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestNewHTTPClientRejectsMismatchedServerName(t *testing.T) {
+	server, roots := newTestTLSServer(t)
+
+	client := newHTTPClient("not-in-the-certificate.example")
+	trustRoots(t, client, roots)
+
+	resp, err := client.Get(server.URL)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("expected certificate verification to fail for a name the certificate does not cover")
+	}
+}
+
+func TestHTTPClientOrDefault(t *testing.T) {
+	if httpClientOrDefault(nil) == nil {
+		t.Fatal("expected a usable client for a nil argument")
+	}
+
+	client := &http.Client{}
+	if httpClientOrDefault(client) != client {
+		t.Fatal("expected the provided client to be returned unchanged")
+	}
+}

--- a/internal/langfuse/llm_connections_client.go
+++ b/internal/langfuse/llm_connections_client.go
@@ -63,12 +63,12 @@ type llmConnectionsClientImpl struct {
 	httpClient *http.Client
 }
 
-func NewLlmConnectionsClient(host, publicKey, privateKey string) LlmConnectionsClient {
+func NewLlmConnectionsClient(host, publicKey, privateKey string, httpClient *http.Client) LlmConnectionsClient {
 	return &llmConnectionsClientImpl{
 		host:       host,
 		publicKey:  publicKey,
 		privateKey: privateKey,
-		httpClient: &http.Client{},
+		httpClient: httpClientOrDefault(httpClient),
 	}
 }
 

--- a/internal/langfuse/organization_client.go
+++ b/internal/langfuse/organization_client.go
@@ -161,12 +161,12 @@ type organizationClientImpl struct {
 	httpClient *http.Client
 }
 
-func NewOrganizationClient(host, publicKey, privateKey string) OrganizationClient {
+func NewOrganizationClient(host, publicKey, privateKey string, httpClient *http.Client) OrganizationClient {
 	return &organizationClientImpl{
 		host:       host,
 		publicKey:  publicKey,
 		privateKey: privateKey,
-		httpClient: &http.Client{},
+		httpClient: httpClientOrDefault(httpClient),
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -19,8 +19,9 @@ type langfuseProvider struct {
 }
 
 type langfuseProviderModel struct {
-	Host        types.String `tfsdk:"host"`
-	AdminAPIKey types.String `tfsdk:"admin_api_key"`
+	Host          types.String `tfsdk:"host"`
+	AdminAPIKey   types.String `tfsdk:"admin_api_key"`
+	TLSServerName types.String `tfsdk:"tls_server_name"`
 }
 
 func (p *langfuseProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -40,6 +41,10 @@ func (p *langfuseProvider) Schema(ctx context.Context, req provider.SchemaReques
 				Sensitive:   true,
 				Description: "Admin API key. Only needed when managing organizations. Can also come from LANGFUSE_ADMIN_KEY.",
 			},
+			"tls_server_name": schema.StringAttribute{
+				Optional:    true,
+				Description: "Hostname to verify the TLS certificate against, also sent as the SNI value. Set this when the instance is reached through a port forward or tunnel, where the host above (typically localhost) cannot match the certificate. Certificate verification remains enabled.",
+			},
 		},
 	}
 }
@@ -52,7 +57,7 @@ func (p *langfuseProvider) Configure(ctx context.Context, req provider.Configure
 		return
 	}
 
-	if config.Host.IsUnknown() || config.AdminAPIKey.IsUnknown() {
+	if config.Host.IsUnknown() || config.AdminAPIKey.IsUnknown() || config.TLSServerName.IsUnknown() {
 		return
 	}
 
@@ -66,7 +71,7 @@ func (p *langfuseProvider) Configure(ctx context.Context, req provider.Configure
 		apiKey = config.AdminAPIKey.ValueString()
 	}
 
-	clientFactory := langfuse.NewClientFactory(host, apiKey)
+	clientFactory := langfuse.NewClientFactory(host, apiKey, config.TLSServerName.ValueString())
 	resp.DataSourceData = clientFactory
 	resp.ResourceData = clientFactory
 }


### PR DESCRIPTION
## Problem

Self-hosted Langfuse instances are frequently not reachable directly. Ours sits behind an internal AWS load balancer, and Terraform reaches it through an SSM port-forward; SSH tunnels and `kubectl port-forward` create the same situation.

In all of these cases the provider connects to `localhost:<port>`. That never matches the certificate the instance serves, so TLS verification fails on hostname mismatch. Since the provider exposes no way to influence the TLS handshake, the only workable option today is plaintext HTTP, which means adding an HTTP listener to an otherwise TLS-only internal endpoint purely to satisfy Terraform.

## Change

Adds an optional `tls_server_name` provider attribute that sets `tls.Config.ServerName`. The certificate is verified against that name and it is sent as the SNI value, while the TCP connection still goes to the tunnel:

```hcl
provider "langfuse" {
  host            = "https://localhost:8080"
  tls_server_name = "langfuse.internal.example.com"
  admin_api_key   = var.admin_api_key
}
```

Certificate verification remains fully enabled. This is deliberately narrower than an `insecure_skip_verify` style option: it solves a naming problem without giving up authentication of the server. It mirrors `curl --resolve` and `kubectl --tls-server-name`.

The HTTP client is now built once in `NewClientFactory` and shared by the admin, organization, and LLM connection clients rather than each constructing its own. Constructors accept a `*http.Client` and tolerate `nil`.

## Compatibility

When `tls_server_name` is unset, the client is identical to the one built before this change, so existing configurations are unaffected. The widened constructor signatures are all in `internal/`, so no external consumer can be broken.

## Testing

`make test` passes. New tests in `internal/langfuse/http_client_test.go` cover the mechanism specifically. The `httptest` certificate covers both `example.com` and `127.0.0.1`, so verifying against the URL host would pass on the IP SAN alone and prove nothing; instead one test verifies against `example.com` and succeeds while another verifies against a name the certificate does not cover and fails the handshake. Together they show the override is what is actually being checked.

`make docs` regenerated `docs/index.md`. Note that running it also produces `docs/resources/llm_connection.md` and `docs/resources/project_membership.md`, which appear to have never been committed; I left those out to keep this PR focused.