### PR TITLE
fix(organization): retry delete while async project cleanup completes

### DIFF
--- a/internal/provider/organization_resource.go
+++ b/internal/provider/organization_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -16,6 +17,15 @@ import (
 
 var _ resource.Resource = &organizationResource{}
 var _ resource.ResourceWithImportState = &organizationResource{}
+
+// Langfuse deletes an organization's projects asynchronously, so an organization
+// delete issued right after its projects are removed can transiently fail until
+// that background cleanup completes. Delete polls with these settings; they are
+// package variables so tests can shrink them.
+var (
+	organizationDeleteTimeout      = 5 * time.Minute
+	organizationDeletePollInterval = 5 * time.Second
+)
 
 func NewOrganizationResource() resource.Resource {
 	return &organizationResource{}
@@ -210,27 +220,40 @@ func (r *organizationResource) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 
-	err := r.AdminClient.DeleteOrganization(ctx, data.ID.ValueString())
-	if err != nil {
-		// Handle the case where organization has existing projects
-		// This is common during test cleanup when dependencies aren't deleted in perfect order
-		if strings.Contains(err.Error(), "Cannot delete organization with existing projects") {
-			resp.Diagnostics.AddWarning(
-				"Organization deletion skipped",
-				"Organization still has existing projects. This is expected during test cleanup - "+
-					"the Docker environment cleanup will handle resource removal. Error: "+err.Error(),
-			)
-		} else {
+	// Langfuse removes an organization's projects asynchronously, so the delete can
+	// transiently fail with "Cannot delete organization with existing projects" while
+	// that background cleanup is still in flight. Poll-retry until it succeeds instead
+	// of swallowing the error and dropping the resource from state, which would leave
+	// the organization orphaned in a persistent (non-ephemeral) Langfuse instance.
+	deadline := time.Now().Add(organizationDeleteTimeout)
+	for {
+		err := r.AdminClient.DeleteOrganization(ctx, data.ID.ValueString())
+		if err == nil {
+			// Deletion succeeded; the framework removes the resource from state.
+			return
+		}
+
+		if !strings.Contains(err.Error(), "Cannot delete organization with existing projects") {
 			resp.Diagnostics.AddError("Error deleting organization", err.Error())
 			return
 		}
-	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &organizationResourceModel{
-		ID:       types.StringValue(""),
-		Name:     types.StringValue(""),
-		Metadata: types.MapNull(types.StringType),
-	})...)
+		if time.Now().After(deadline) {
+			resp.Diagnostics.AddError(
+				"Error deleting organization",
+				"timed out after "+organizationDeleteTimeout.String()+" waiting for the organization's "+
+					"projects to finish deleting so the organization could be removed. Last error: "+err.Error(),
+			)
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			resp.Diagnostics.AddError("Error deleting organization", ctx.Err().Error())
+			return
+		case <-time.After(organizationDeletePollInterval):
+		}
+	}
 }
 
 func (r *organizationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/organization_resource_unit_test.go
+++ b/internal/provider/organization_resource_unit_test.go
@@ -2,8 +2,10 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 
@@ -285,6 +287,79 @@ func TestOrganizationResourceCRUD(t *testing.T) {
 			if actualValue, exists := actualMetadata[key]; !exists || actualValue != expectedValue {
 				t.Fatalf("unexpected metadata for key %q. got %q, want %q", key, actualValue, expectedValue)
 			}
+		}
+	})
+}
+
+func TestOrganizationResourceDeleteRetriesWhileProjectsClear(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	r := NewOrganizationResource().(*organizationResource)
+	clientFactory := mocks.NewMockClientFactory(ctrl)
+
+	var configureResp resource.ConfigureResponse
+	r.Configure(ctx, resource.ConfigureRequest{ProviderData: clientFactory}, &configureResp)
+	if configureResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Configure: %v", configureResp.Diagnostics)
+	}
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	resourceSchema := schemaResp.Schema
+
+	state := tfsdk.State{
+		Raw: buildObjectValue(map[string]tftypes.Value{
+			"id":       tftypes.NewValue(tftypes.String, "org-123"),
+			"name":     tftypes.NewValue(tftypes.String, "Acme Inc"),
+			"metadata": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{}),
+		}),
+		Schema: resourceSchema,
+	}
+
+	// The client surfaces the API's 400 body verbatim (see internal/langfuse/utils.go).
+	existingProjectsErr := errors.New(
+		`request failed with status code 400, response body: ` +
+			`{"error":"Cannot delete organization with existing projects"}`,
+	)
+
+	origInterval, origTimeout := organizationDeletePollInterval, organizationDeleteTimeout
+	organizationDeletePollInterval = time.Millisecond
+	organizationDeleteTimeout = 5 * time.Second
+	defer func() {
+		organizationDeletePollInterval = origInterval
+		organizationDeleteTimeout = origTimeout
+	}()
+
+	t.Run("retries transient existing-projects error then succeeds", func(t *testing.T) {
+		gomock.InOrder(
+			clientFactory.AdminClient.EXPECT().DeleteOrganization(ctx, "org-123").Return(existingProjectsErr),
+			clientFactory.AdminClient.EXPECT().DeleteOrganization(ctx, "org-123").Return(existingProjectsErr),
+			clientFactory.AdminClient.EXPECT().DeleteOrganization(ctx, "org-123").Return(nil),
+		)
+
+		var deleteResp resource.DeleteResponse
+		deleteResp.State.Schema = resourceSchema
+		r.Delete(ctx, resource.DeleteRequest{State: state}, &deleteResp)
+
+		if deleteResp.Diagnostics.HasError() {
+			t.Fatalf("expected Delete to succeed once projects cleared, got: %v", deleteResp.Diagnostics)
+		}
+	})
+
+	t.Run("errors instead of orphaning when projects never clear", func(t *testing.T) {
+		organizationDeleteTimeout = time.Nanosecond // force a timeout after the first attempt
+		clientFactory.AdminClient.EXPECT().DeleteOrganization(ctx, "org-123").Return(existingProjectsErr)
+
+		var deleteResp resource.DeleteResponse
+		deleteResp.State.Schema = resourceSchema
+		r.Delete(ctx, resource.DeleteRequest{State: state}, &deleteResp)
+
+		if !deleteResp.Diagnostics.HasError() {
+			t.Fatalf("expected Delete to error on timeout so the org stays in state, got no error diagnostics")
 		}
 	})
 }


### PR DESCRIPTION
The organization Delete swallowed the API's 400 "Cannot delete organization with existing projects" as a warning and then let the framework remove the resource from state. Langfuse deletes an org's projects asynchronously, so that error is transient — but treating it as success orphans the organization in any persistent (non-Docker-test) instance: gone from Terraform state, still present in Langfuse.

Delete now polls DeleteOrganization until the async project cleanup finishes (configurable timeout, default 5m), and returns a real error on any other failure or on timeout so the resource stays in state and a re-apply retries.

Adds unit coverage for the retry-then-succeed and timeout paths.

not tested